### PR TITLE
New logger

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -4,8 +4,8 @@ What's New
 v0.1.5 (???)
 ------------
 
+- Adds new logger that leverages on built-in python logging.
 - Changed license to MIT
-
 
 
 v0.1.4 (22 Oct 2015)

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -329,8 +329,11 @@ class Model(PseudoSpectralKernel):
         if not self.logger.handlers:
             self.logger.addHandler(fhandler)
 
-        #self.logger.setLevel(logging.DEBUG)
         self.logger.setLevel(self.log_level*10)
+        
+        # this prevents the logger to propagate into the ipython notebook log
+        self.logger.propagate = False   
+
         self.logger.info(' Logger initialized')
 
 

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -84,6 +84,7 @@ class Model(PseudoSpectralKernel):
         #teststyle = False,            # use fftw with "estimate" planner to get reproducibility
         ntd = 1,                    # number of threads to use in fftw computations
         quiet = False,
+        logfile = None,        
         ):
         """
         .. note:: All of the test cases use ``nx==ny``. Expect bugs if you choose
@@ -143,6 +144,7 @@ class Model(PseudoSpectralKernel):
         self.tavestart = tavestart
         self.taveint = taveint
         self.quiet = quiet
+        self.logfile = logfile
         self.useAB2 = useAB2
         # fft 
         #self.use_fftw = use_fftw

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -83,7 +83,8 @@ class Model(PseudoSpectralKernel):
         #use_fftw = False,               # fftw flag 
         #teststyle = False,            # use fftw with "estimate" planner to get reproducibility
         ntd = 1,                       # number of threads to use in fftw computations
-        quiet = False,                 # no-printout flag
+        log_level = 1,                 # logger level: from 0 for quiet (no log) to 4 for verbose
+                                       #     logger (see  https://docs.python.org/2/library/logging.html)
         logfile = None,                # logfile; None prints to screen
         ):
         """
@@ -143,8 +144,8 @@ class Model(PseudoSpectralKernel):
         self.tmax = tmax
         self.tavestart = tavestart
         self.taveint = taveint
-        self.quiet = quiet
         self.logfile = logfile
+        self.log_level = log_level
         self.useAB2 = useAB2
         # fft 
         #self.use_fftw = use_fftw
@@ -328,7 +329,8 @@ class Model(PseudoSpectralKernel):
         if not self.logger.handlers:
             self.logger.addHandler(fhandler)
 
-        self.logger.setLevel(logging.DEBUG)
+        #self.logger.setLevel(logging.DEBUG)
+        self.logger.setLevel(self.log_level*10)
         self.logger.info(' Logger initialized')
 
 
@@ -357,7 +359,7 @@ class Model(PseudoSpectralKernel):
         
     def _print_status(self):
         """Output some basic stats."""
-        if (not self.quiet) and ((self.tc % self.twrite)==0) and self.tc>0.:
+        if (self.log_level) and ((self.tc % self.twrite)==0) and self.tc>0.:
             self.ke = self._calc_ke()
             self.cfl = self._calc_cfl()
             #print 't=%16d, tc=%10d: cfl=%5.6f, ke=%9.9f' % (

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -363,7 +363,7 @@ class Model(PseudoSpectralKernel):
             #print 't=%16d, tc=%10d: cfl=%5.6f, ke=%9.9f' % (
             #       self.t, self.tc, cfl, ke)
             self.logger.info(' Step: %i, Time: %e, KE: %e, CFL: %f'
-                    %(self.tc,self.t,self.ke,self.cfl))
+                    , self.tc,self.t,self.ke,self.cfl )
 
             assert self.cfl<1., self.logger.error('CFL condition violated')
             

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -82,9 +82,9 @@ class Model(PseudoSpectralKernel):
         # removed because fftw is now manditory
         #use_fftw = False,               # fftw flag 
         #teststyle = False,            # use fftw with "estimate" planner to get reproducibility
-        ntd = 1,                    # number of threads to use in fftw computations
-        quiet = False,
-        logfile = None,        
+        ntd = 1,                       # number of threads to use in fftw computations
+        quiet = False,                 # no-printout flag
+        logfile = None,                # logfile; None prints to screen
         ):
         """
         .. note:: All of the test cases use ``nx==ny``. Expect bugs if you choose


### PR DESCRIPTION
Ok. I'll submit smaller incremental PRs to master with those changes in ```develop```. Many of those commits were just me trying to get things working, so this should be relatively fast, easy to review, and less frustrating than solving conflicts. After this process is done we'll extinguish ```develop```.

This implements a new logger that leverages on python's logging tools. There are many advantages, including discriminating into types of information: INFO, WARNING, ERROR, etc.  By default
```logfile=None```, but if the logfile is specified then the log is saved to disk instead of printing out on the screen. 

An example of logger output from ```test_two-layer.py```

```{python}
crocha (new_logger) tests $ python test_twolayer_qg.py

2015-10-25 14:37:51,694 - pyqg.model - INFO -  Logger initialized
2015-10-25 14:37:51,723 - pyqg.model - INFO -  Kernel initialized
2015-10-25 14:37:52,596 - pyqg.model - INFO -  Step: 1000, Time: 1.280000e+07, KE: 3.570417e-05, CFL: 0.021194
2015-10-25 14:37:53,449 - pyqg.model - INFO -  Step: 2000, Time: 2.560000e+07, KE: 8.905682e-05, CFL: 0.021312
2015-10-25 14:37:54,262 - pyqg.model - INFO -  Step: 3000, Time: 3.840000e+07, KE: 2.223634e-04, CFL: 0.026741
2015-10-25 14:37:55,050 - pyqg.model - INFO -  Step: 4000, Time: 5.120000e+07, KE: 5.554657e-04, CFL: 0.042373
2015-10-25 14:37:55,845 - pyqg.model - INFO -  Step: 5000, Time: 6.400000e+07, KE: 1.388770e-03, CFL: 0.066468
2015-10-25 14:37:56,644 - pyqg.model - INFO -  Step: 6000, Time: 7.680000e+07, KE: 3.473293e-03, CFL: 0.105027
2015-10-25 14:37:57,440 - pyqg.model - INFO -  Step: 7000, Time: 8.960000e+07, KE: 2.862242e-03, CFL: 0.107483
time:       9.3312e+07

```
