### PR TITLE
Removes redundant _calc_diag from subclass

### DIFF
--- a/pyqg/qg_model.py
+++ b/pyqg/qg_model.py
@@ -205,11 +205,6 @@ class QGModel(model.Model):
         #self.Ubg = np.array([U1,U2])[:,np.newaxis,np.newaxis]
         self.Ubg = np.array([U1,U2])
 
-    def _calc_diagnostics(self):
-        # here is where we calculate diagnostics
-        if (self.t>=self.dt) and (self.tc%self.taveints==0):
-            self._increment_diagnostics()
-
     ### All the diagnostic stuff follows. ###
     def _calc_cfl(self):
         return np.abs(


### PR DESCRIPTION
This removes the ```_calc_diagnostics()``` method from the ```QGModel``` (two-layer) subclass. The issue here is similar to that in #103. In fact, the redundant method in the ```LayeredModel``` subclass was simply a legacy from the QGModel subclass. This goes back to the [split] (http://git.io/vWHum) into a [main ``Model`` class](http://git.io/vWH2p) and the [```QGModel``` subclass](http://git.io/vWHar).

