### PR TITLE
refactoring travisci build with python 3 tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit = pyqg/tests/*
+       pyqg/__init__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,51 @@
-# based on this
-# https://gist.github.com/dan-blanchard/7045057
+# Based on http://conda.pydata.org/docs/travis.html
 language: python
-sudo: false
-python:
-  - 2.7
-#  - 3.3
+sudo: false # use container based build
 notifications:
   email: false
 
-# Setup anaconda
+matrix:
+  fast_finish: true
+  include:
+  - python: 2.7
+    env: CONDA_ENV=py27
+  - python: 2.7
+    env: CONDA_ENV=py27-pyfftw
+  - python: 3.5
+    env: CONDA_ENV=py35
+  - python: 3.5
+    env: CONDA_ENV=py35-pyfftw
+
 before_install:
-# python 3 needs something different
-  - pip install codecov
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p $HOME/miniconda
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-# Install packages
-install:
-  - conda create --yes -n test_env python=$TRAVIS_PYTHON_VERSION pip nose numpy=1.9.3 cython scipy=0.16.0
-  # can we make this optional?
-  - conda install --yes -n test_env -c mforbes pyfftw
-  - source activate test_env
-# build the kernel in the local dir
-  - python setup.py build_ext --inplace
-# not necessary to actually install
-# nose will import the pacakge from the working directory
-#  - python setup.py install
 
-# Run test
+install:
+  - conda env create --file ci/environment-$CONDA_ENV.yml
+  - source activate test_env
+# if we do this, the package gets installed into
+# /home/travis/build/xgcm/xgcm/build/lib/xgcm
+#  - python setup.py install
+  - python setup.py build_ext --inplace
+  - pip install -e .
+# this puts the package into
+# /home/travis/build/xgcm/xgcm/xgcm
+# That turns out to be necessary for py.test to correctly collect the tests
+# and for coverage to work properly.
+# It is very complicated and confusing.
+
 script:
-  - nosetests -v
-# Calculate coverage
+#  - py.test xgcm --cov=xgcm --cov-config .coveragerc --cov-report term-missing
+  - py.test
+
 after_success:
-# codecov can't be found because we are in virtual environment? no that doesn't seem right
-#  - source deactivate
-  - codecov
-#  - coveralls --config_file .coveragerc
+#  - codecov

--- a/ci/environment-py27-pyfftw.yml
+++ b/ci/environment-py27-pyfftw.yml
@@ -1,0 +1,16 @@
+name: test_env
+channels:
+# for pyfftw
+#  - mforbes # old, doesn't support 3.5
+  - nanshe
+dependencies:
+  - python=2.7
+  - numpy
+  - scipy
+  - cython
+  - pyfftw
+  - pytest
+  - future
+  - pip:
+    - codecov
+    - pytest-cov

--- a/ci/environment-py27.yml
+++ b/ci/environment-py27.yml
@@ -1,0 +1,11 @@
+name: test_env
+dependencies:
+  - python=2.7
+  - numpy
+  - scipy
+  - cython
+  - pytest
+  - future
+  - pip:
+    - codecov
+    - pytest-cov

--- a/ci/environment-py35-pyfftw.yml
+++ b/ci/environment-py35-pyfftw.yml
@@ -1,0 +1,16 @@
+name: test_env
+channels:
+# for pyfftw
+#  - mforbes # old, doesn't support 3.5
+  - nanshe
+dependencies:
+  - python=3.5
+  - numpy
+  - scipy
+  - cython
+  - pyfftw
+  - pytest
+  - future
+  - pip:
+    - codecov
+    - pytest-cov

--- a/ci/environment-py35.yml
+++ b/ci/environment-py35.yml
@@ -1,0 +1,11 @@
+name: test_env
+dependencies:
+  - python=3.5
+  - numpy
+  - scipy
+  - cython
+  - pytest
+  - future
+  - pip:
+    - codecov
+    - pytest-cov

--- a/pyqg/tests/test_fftw.py
+++ b/pyqg/tests/test_fftw.py
@@ -1,8 +1,16 @@
 import numpy as np
 from numpy import pi
 import time
-import pyfftw
+import pytest
 
+# hack to skip tests if we don't have pyfft
+try:
+    import pyfftw
+    skip=False
+except ImportError:
+    skip=True
+
+@pytest.mark.skipif(skip, reason="Can't test fftw without pyfftw")
 def test_fftw_rfft2(Nx = 64, Ny = None, n = 7200):
     """ A verification of rfft2/irfft2 pyfftw accuracy lost... """
 
@@ -29,6 +37,7 @@ def test_fftw_rfft2(Nx = 64, Ny = None, n = 7200):
     print("Relative error after %i Forward/Inverse FFTs = %e " %(n,rel_err))
     print(" ")
 
+@pytest.mark.skipif(skip, reason="Can't test fftw without pyfftw")
 def test_fftw_rfft(Nx = 64, n = 100000):
     """ A verification of rfft/irfft accuracy lost """
 

--- a/pyqg/tests/test_import.py
+++ b/pyqg/tests/test_import.py
@@ -1,7 +1,0 @@
-def test_answer():
-    import numpy
-    #import mkl
-    import pyfftw
-    import pyqg
-
-

--- a/setup.py
+++ b/setup.py
@@ -64,19 +64,19 @@ install_requires = [
 
 # This hack tells cython whether pyfftw is present
 use_pyfftw_file = 'pyqg/.compile_time_use_pyfftw.pxi'
-with open(use_pyfftw_file, 'w') as f:
+with open(use_pyfftw_file, 'wb') as f:
     try:
         import pyfftw
-        f.write('DEF PYQG_USE_PYFFTW = 1')
+        f.write(b'DEF PYQG_USE_PYFFTW = 1')
     except ImportError:
-        f.write('DEF PYQG_USE_PYFFTW = 0')
+        f.write(b'DEF PYQG_USE_PYFFTW = 0')
         warnings.warn('Could not import pyfftw. Model will be slow.')
 
 # check for openmp following
 # http://stackoverflow.com/questions/16549893/programatically-testing-for-openmp-support-from-a-python-setup-script
 # see http://openmp.org/wp/openmp-compilers/
 omp_test = \
-r"""
+br"""
 #include <omp.h>
 #include <stdio.h>
 int main() {
@@ -84,6 +84,8 @@ int main() {
 printf("Hello from thread %d, nthreads %d\n", omp_get_thread_num(), omp_get_num_threads());
 }
 """
+
+# python 3 needs rb
 
 def check_for_openmp():
     tmpdir = tempfile.mkdtemp()
@@ -94,12 +96,12 @@ def check_for_openmp():
         cc = os.environ['CC']
     except KeyError:
         cc = 'gcc'
-    with open(filename, 'w', 0) as file:
+    with open(filename, 'wb', 0) as file:
         file.write(omp_test)
-    with open(os.devnull, 'w') as fnull:
+    with open(os.devnull, 'wb') as fnull:
         result = subprocess.call([cc, '-fopenmp', filename],
                                  stdout=fnull, stderr=fnull)
-    print 'check_for_openmp() result: ', result
+    print('check_for_openmp() result: ', result)
     os.chdir(curdir)
     #clean up
     shutil.rmtree(tmpdir)
@@ -122,7 +124,7 @@ else:
 #if on_rtd:
 #    install_requires.remove('pyfftw')
 
-tests_require = ['nose']
+tests_require = ['pytest']
 
 def readme():
     with open('README.md') as f:


### PR DESCRIPTION
A sample build with the new setup:
https://travis-ci.org/rabernat/pyqg/builds/118349708

fixes #130 

updated channel specification
trying with and without pyfftw
hack to skip tests that rely on pyfftw
got rid of unnecessary import test
added missing yaml files
fix setup.py print statements
try to make test skipping work
fixing of setup.py strings for python 3
