### PR TITLE
python 3 compatibility

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit = pyqg/tests/*
+       pyqg/__init__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,51 @@
-# based on this
-# https://gist.github.com/dan-blanchard/7045057
+# Based on http://conda.pydata.org/docs/travis.html
 language: python
-sudo: false
-python:
-  - 2.7
-#  - 3.3
+sudo: false # use container based build
 notifications:
   email: false
 
-# Setup anaconda
+matrix:
+  fast_finish: true
+  include:
+  - python: 2.7
+    env: CONDA_ENV=py27
+  - python: 2.7
+    env: CONDA_ENV=py27-pyfftw
+  - python: 3.5
+    env: CONDA_ENV=py35
+  - python: 3.5
+    env: CONDA_ENV=py35-pyfftw
+
 before_install:
-# python 3 needs something different
-  - pip install codecov
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p $HOME/miniconda
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-# Install packages
-install:
-  - conda create --yes -n test_env python=$TRAVIS_PYTHON_VERSION pip nose numpy=1.9.3 cython scipy=0.16.0
-  # can we make this optional?
-  - conda install --yes -n test_env -c mforbes pyfftw
-  - source activate test_env
-# build the kernel in the local dir
-  - python setup.py build_ext --inplace
-# not necessary to actually install
-# nose will import the pacakge from the working directory
-#  - python setup.py install
 
-# Run test
+install:
+  - conda env create --file ci/environment-$CONDA_ENV.yml
+  - source activate test_env
+# if we do this, the package gets installed into
+# /home/travis/build/xgcm/xgcm/build/lib/xgcm
+#  - python setup.py install
+  - python setup.py build_ext --inplace
+  - pip install -e .
+# this puts the package into
+# /home/travis/build/xgcm/xgcm/xgcm
+# That turns out to be necessary for py.test to correctly collect the tests
+# and for coverage to work properly.
+# It is very complicated and confusing.
+
 script:
-  - nosetests -v
-# Calculate coverage
+#  - py.test xgcm --cov=xgcm --cov-config .coveragerc --cov-report term-missing
+  - py.test
+
 after_success:
-# codecov can't be found because we are in virtual environment? no that doesn't seem right
-#  - source deactivate
-  - codecov
-#  - coveralls --config_file .coveragerc
+#  - codecov

--- a/ci/environment-py27-pyfftw.yml
+++ b/ci/environment-py27-pyfftw.yml
@@ -1,0 +1,16 @@
+name: test_env
+channels:
+# for pyfftw
+#  - mforbes # old, doesn't support 3.5
+  - nanshe
+dependencies:
+  - python=2.7
+  - numpy
+  - scipy
+  - cython
+  - pyfftw
+  - pytest
+  - future
+  - pip:
+    - codecov
+    - pytest-cov

--- a/ci/environment-py27.yml
+++ b/ci/environment-py27.yml
@@ -1,0 +1,11 @@
+name: test_env
+dependencies:
+  - python=2.7
+  - numpy
+  - scipy
+  - cython
+  - pytest
+  - future
+  - pip:
+    - codecov
+    - pytest-cov

--- a/ci/environment-py35-pyfftw.yml
+++ b/ci/environment-py35-pyfftw.yml
@@ -1,0 +1,16 @@
+name: test_env
+channels:
+# for pyfftw
+#  - mforbes # old, doesn't support 3.5
+  - nanshe
+dependencies:
+  - python=3.5
+  - numpy
+  - scipy
+  - cython
+  - pyfftw
+  - pytest
+  - future
+  - pip:
+    - codecov
+    - pytest-cov

--- a/ci/environment-py35.yml
+++ b/ci/environment-py35.yml
@@ -1,0 +1,11 @@
+name: test_env
+dependencies:
+  - python=3.5
+  - numpy
+  - scipy
+  - cython
+  - pytest
+  - future
+  - pip:
+    - codecov
+    - pytest-cov

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -125,7 +125,7 @@ install it, check the version, and tear down the virtual environment.
 .. code-block:: bash
 
     $ conda create --yes -n test_env python=2.7 pip nose numpy cython scipy nose
-    $ conda install --yes -n test_env -c mforbes pyfftw
+    $ conda install --yes -n test_env -c nanshe pyfftw
     $ source activate test_env
     $ pip install pyqg
     $ python -c 'import pyqg; print(pyqg.__version__);'

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Requirements
 
 The only requirements are
 
-- Python 2.7. (Python 3 support is in the works) 
+- Python 2.7. (Python 3 support is in the works)
 - numpy_ (1.6 or later)
 - Cython (0.2 or later)
 
@@ -65,25 +65,24 @@ distributed as a conda pacakge through several `user channels
 
 There is a useful `blog post
 <https://dranek.com/blog/2014/Feb/conda-binstar-and-fftw/>`__ describing how
-the pyfftw conda package was created. There are currently 13 
+the pyfftw conda package was created. There are currently 13
 `pyfftw user packages <https://anaconda.org/search?q=pyfftw>`__
 hosted on anaconda.org. Each has different dependencies and platform support
-(e.g. linux, windows, mac.) 
-The `mforbes <https://anaconda.org/mforbes>`__ channel version was selected
-for this documentation because its pyfftw package is compatible with the
-latest version of numpy (1.9.2) and both linux and mac platforms. We don't know
-who mforbes is, but we are greatful to him/her.
+(e.g. linux, windows, mac.)
+The `nanshe <https://anaconda.org/nanshe/pyfftw>`__ channel version is the most
+popular and appears to have the broadest cross-platform support. We don't know
+who nanshe is, but we are greatful to him/her.
 
-To install pyfftw from the mforbes channel, open a terminal and run
+To install pyfftw from the nanshe channel, open a terminal and run
 the command
 
 .. code-block:: bash
 
-    $ conda install -c mforbes pyfftw
+    $ conda install -c nanshe pyfftw
 
 If this doesn't work for you, or if it asks you to upgrade / downgrade more of
 your core pacakges (e.g. numpy) than you would like, you can easily try
-replacing ``mforbes`` with one of the other `channels
+replacing ``nanshe`` with one of the other `channels
 <https://anaconda.org/search?q=pyfftw>`__.
 
 The hard way: installing from source
@@ -133,18 +132,18 @@ Then install the software
 
     $ sudo make install
 
-This will install the FFTW3 libraries into you system's library directory. 
+This will install the FFTW3 libraries into you system's library directory.
 If you don't have root privileges (see note above), remove the ``sudo``. This
 will install the libraries into the ``prefix`` location you specified.
 
-You are not done installing FFTW yet. pyfftw requires special versions 
+You are not done installing FFTW yet. pyfftw requires special versions
 of the FFTW library specialized to different data types (32-bit floats and
 double-long floars). You need to-configure and re-build FFTW two more times
-with extra flags. 
+with extra flags.
 
 .. code-block:: bash
 
-    $ ./configure --enable-threads --enable-shared --enable-float 
+    $ ./configure --enable-threads --enable-shared --enable-float
     $ make
     $ sudo make install
     $ ./configure --enable-threads --enable-shared --enable-long-double
@@ -180,7 +179,7 @@ Then install it
     $ cd pyFFTW
     $ python setup.py install
 
-or 
+or
 
 .. code-block:: bash
 
@@ -200,7 +199,7 @@ Installing pyqg
     If you are using Mac OSX Yosemite or later OpenMP support is not available out of the box.  While pyqg will
     still run without OpenMP, it will not be as fast as it can be. See :ref:`advanced-install` below for more
     information on installing on OSX with OpenMP support.
-    
+
 With pyfftw installed, you can now install pyqg. The easiest way is with pip:
 
 .. code-block:: bash
@@ -208,7 +207,7 @@ With pyfftw installed, you can now install pyqg. The easiest way is with pip:
     $ pip install pyqg
 
 You can also clone the `pyqg git repository <https://github.com/pyqg/pyqg>`__ to
-use the latest development version. 
+use the latest development version.
 
 .. code-block:: bash
 
@@ -257,7 +256,7 @@ Install Cython from the conda repository
 Install pyqg using the homebrew ``gcc`` compiler
 
 .. code-block:: bash
-    
+
     $ CC=/usr/local/bin/gcc-5 pip install pyqg
 
 
@@ -274,8 +273,5 @@ Install Cython from the conda repository
 Install pyqg using the HPC ``gcc`` compiler
 
 .. code-block:: bash
-    
-    $ CC=/usr/local/bin/gcc pip install pyqg
-    
 
-    
+    $ CC=/usr/local/bin/gcc pip install pyqg

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -4,6 +4,8 @@ What's New
 v0.1.5 (???)
 ------------
 
+Added compatibility with python 3.
+
 Implemented linear baroclinic stability analysis method.
 
 Implemented vertical mode methods and modal KE and PE spectra diagnostics.
@@ -12,7 +14,7 @@ Implemented multi-layer subclass.
 
 Added new logger that leverages on built-in python logging.
 
-Changed license to MIT
+Changed license to MIT.
 
 v0.1.4 (22 Oct 2015)
 --------------------

--- a/pyqg/__init__.py
+++ b/pyqg/__init__.py
@@ -1,7 +1,7 @@
 __version__='0.1.3'
-from model import Model
-from qg_model import QGModel
-from bt_model import BTModel
-from sqg_model import SQGModel
-from layered_model import LayeredModel
-from particles import LagrangianParticleArray2D, GriddedLagrangianParticleArray2D
+from .model import Model
+from .qg_model import QGModel
+from .bt_model import BTModel
+from .sqg_model import SQGModel
+from .layered_model import LayeredModel
+from .particles import LagrangianParticleArray2D, GriddedLagrangianParticleArray2D

--- a/pyqg/bt_model.py
+++ b/pyqg/bt_model.py
@@ -1,6 +1,7 @@
+from __future__ import print_function
 import numpy as np
-import model
 from numpy import pi
+from . import model
 
 
 class BTModel(model.Model):
@@ -8,7 +9,7 @@ class BTModel(model.Model):
     This class can represent both pure two-dimensional flow
     and also single reduced-gravity layers with deformation
     radius ``rd``.
-    
+
     The equivalent-barotropic quasigeostrophic evolution equations is
 
     .. math::
@@ -20,14 +21,14 @@ class BTModel(model.Model):
     .. math::
 
        q = \nabla^2 \psi - \kappa_d^2 \psi
-       
+
     """
-    
+
     def __init__(self, beta=0.,  rd=0., H=1., U=0., **kwargs):
         """
         Parameters
         ----------
-        
+
         beta : number, optional
             Gradient of coriolis parameter. Units: meters :sup:`-1`
             seconds :sup:`-1`
@@ -41,36 +42,36 @@ class BTModel(model.Model):
         self.rd = rd
         self.H = H
         self.U = U
-        
+
         self.nz = 1
-       
+
         # deformation wavenumber
         if rd:
             self.kd2 = rd**-2
         else:
             self.kd2 = 0.
-    
+
         super(BTModel, self).__init__(**kwargs)
-     
+
         # initial conditions: (PV anomalies)
         self.set_q(1e-3*np.random.rand(1,self.ny,self.nx))
- 
+
     def _initialize_background(self):
         """Set up background state (zonal flow and PV gradients)."""
-        
+
         # the meridional PV gradients in each layer
         self.Qy = np.asarray(self.beta)[np.newaxis, ...]
 
         # background vel.
-        self.set_U(self.U)        
+        self.set_U(self.U)
 
         # complex versions, multiplied by k, speeds up computations to pre-compute
         self.ikQy = self.Qy * 1j * self.k
-        
+
         self.ilQx = 0.
 
     def _initialize_inversion_matrix(self):
-        """ the inversion """ 
+        """ the inversion """
         # The bt model is diagonal. The inversion is simply qh = -kappa**2 ph
         self.a = -(self.wv2i+self.kd2)[np.newaxis, np.newaxis, :, :]
 
@@ -90,10 +91,10 @@ class BTModel(model.Model):
 
     def set_U(self, U):
         """Set background zonal flow.
-        
+
         Parameters
         ----------
-        
+
         U : number
             Upper layer flow. Units meters.
         """
@@ -115,7 +116,7 @@ class BTModel(model.Model):
         ke = .5*self.spec_var(self.wv*self.ph)
         return ke.sum()
 
-    # calculate eddy turn over time 
+    # calculate eddy turn over time
     # (perhaps should change to fraction of year...)
     def _calc_eddy_time(self):
         """ estimate the eddy turn-over time in days """
@@ -127,7 +128,3 @@ class BTModel(model.Model):
     #     self.xi =self.ifft2( -self.wv2*self.ph)
     #     self.Jptpc = -self.advect(self.p,self.u,self.v)
     #     self.Jpxi = self.advect(self.xi, self.u, self.v)
-
-        
-
-

--- a/pyqg/diagnostic_tools.py
+++ b/pyqg/diagnostic_tools.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 """Utility functions for pyqg model data."""
 
 import numpy as np
@@ -5,14 +6,14 @@ from numpy import pi
 
 def spec_var(model, ph):
     """Compute variance of ``p`` from Fourier coefficients ``ph``.
-    
+
     Parameters
     ----------
     model : pyqg.Model instance
         The model object from which `ph` originates
     ph : complex array
         The field on which to compute the variance
-        
+
     Returns
     -------
     var_dens : float
@@ -24,24 +25,24 @@ def spec_var(model, ph):
     var_dens[...,0] /= 2
     var_dens[...,-1] /= 2
     return var_dens.sum(axis=(-1,-2))
-   
+
 
 def spec_sum(ph2):
     """Compute total spectral sum of the real spectral quantity``ph^2``.
-    
+
     Parameters
     ----------
     model : pyqg.Model instance
         The model object from which `ph` originates
     ph2 : real array
         The field on which to compute the sum
-        
+
     Returns
     -------
     var_dens : float
         The sum of `ph2`
-    """    
-    
+    """
+
     ph2 = 2.*ph2
     ph2[...,0] = ph2[...,0]/2.
     ph2[...,-1] = ph2[...,-1]/2.
@@ -51,14 +52,14 @@ def spec_sum(ph2):
 
 def calc_ispec(model, ph):
     """Compute isotropic spectrum `phr` of `ph` from 2D spectrum.
-    
+
     Parameters
     ----------
     model : pyqg.Model instance
         The model object from which `ph` originates
     ph : complex array
         The field on which to compute the variance
-        
+
     Returns
     -------
     kr : array
@@ -66,7 +67,7 @@ def calc_ispec(model, ph):
     phr : array
         isotropic spectrum
     """
-    
+
     if model.kk.max()>model.ll.max():
         kmax = model.ll.max()
     else:
@@ -81,5 +82,5 @@ def calc_ispec(model, ph):
         fkr =  (model.wv>=kr[i]-dkr/2) & (model.wv<=kr[i]+dkr/2)
         dth = pi / (fkr.sum()-1)
         phr[i] = ph[fkr].sum() * kr[i] * dth
-        
+
     return kr, phr

--- a/pyqg/layered_model.py
+++ b/pyqg/layered_model.py
@@ -1,6 +1,8 @@
+from __future__ import print_function
 import numpy as np
-import model
 from numpy import pi
+from . import model
+
 try:
     import mkl
     np.use_fastnumpy = True
@@ -121,7 +123,7 @@ class LayeredModel(model.Model):
         super(LayeredModel, self).__init__(**kwargs)
 
         self.vertical_modes()
-        
+
 
     ### PRIVATE METHODS - not meant to be called by user ###
 
@@ -273,17 +275,17 @@ class LayeredModel(model.Model):
 
         self.add_diagnostic('entspec',
                 description='barotropic enstrophy spectrum',
-                function= (lambda self: 
+                function= (lambda self:
                     np.abs((self.Hi[:,np.newaxis,np.newaxis]*self.qh).sum(axis=0))**2/self.H) )
 
         self.add_diagnostic('KEspec_modal',
                 description='modal KE spectra',
-                function= (lambda self: 
+                function= (lambda self:
                     self.wv2*(np.abs(self.phn)**2)/self.M**2 ))
-        
+
         self.add_diagnostic('PEspec_modal',
                 description='modal PE spectra',
-                function= (lambda self: 
+                function= (lambda self:
                     self.kdi2[1:,np.newaxis,np.newaxis]*(np.abs(self.phn[1:,:,:])**2)/self.M**2 ))
 
         self.add_diagnostic('APEspec',
@@ -317,5 +319,5 @@ class LayeredModel(model.Model):
         self.add_diagnostic('ENSgenspec',
                     description='the spectrum of the rate of generation of barotropic enstrophy',
                     function = (lambda self:
-                            -(self.Hi[:,np.newaxis,np.newaxis]*((self.ikQy - 
+                            -(self.Hi[:,np.newaxis,np.newaxis]*((self.ikQy -
                             self.ilQx)*(self.Sph.conj()*self.ph)).real).sum(axis=0)/self.H))

--- a/pyqg/qg_model.py
+++ b/pyqg/qg_model.py
@@ -1,7 +1,9 @@
+from __future__ import print_function
 import numpy as np
-import model
 from numpy import pi
-try:   
+from . import model
+
+try:
     import mkl
     np.use_fastnumpy = True
 except ImportError:
@@ -9,24 +11,24 @@ except ImportError:
 
 try:
     import pyfftw
-    pyfftw.interfaces.cache.enable() 
+    pyfftw.interfaces.cache.enable()
 except ImportError:
     pass
 
 class QGModel(model.Model):
     r"""Two layer quasigeostrophic model.
-    
+
     This model is meant to representflows driven by baroclinic instabilty of a
     base-state shear :math:`U_1-U_2`. The upper and lower
     layer potential vorticity anomalies :math:`q_1` and :math:`q_2` are
-    
+
     .. math::
-    
+
         q_1 &= \nabla^2\psi_1 + F_1(\psi_2 - \psi_1) \\
         q_2 &= \nabla^2\psi_2 + F_2(\psi_1 - \psi_2)
 
     with
-    
+
     .. math::
         F_1 &\equiv \frac{k_d^2}{1 + \delta^2} \\
         F_2 &\equiv \delta F_1 \ .
@@ -40,7 +42,7 @@ class QGModel(model.Model):
 
         \beta_1 &= \beta + F_1(U_1 - U_2) \\
         \beta_2 &= \beta - F_2( U_1 - U_2) \ .
-    
+
     The evolution equations for :math:`q_1` and :math:`q_2` are
 
     .. math::
@@ -52,10 +54,10 @@ class QGModel(model.Model):
 
     where `ssd` represents small-scale dissipation and :math:`r_{ek}` is the
     Ekman friction parameter.
-    
+
     """
 
-    
+
     def __init__(
         self,
         beta=1.5e-11,               # gradient of coriolis parameter
@@ -95,28 +97,28 @@ class QGModel(model.Model):
         self.U1 = U1
         self.U2 = U2
         #self.filterfac = filterfac
-        
+
         self.nz = 2
-        
+
         super(QGModel, self).__init__(**kwargs)
-        
+
         # initial conditions: (PV anomalies)
         self.set_q1q2(
             1e-7*np.random.rand(self.ny,self.nx) + 1e-6*(
                 np.ones((self.ny,1)) * np.random.rand(1,self.nx) ),
-                np.zeros_like(self.x) )   
-        
-    
-                
+                np.zeros_like(self.x) )
+
+
+
     ### PRIVATE METHODS - not meant to be called by user ###
-        
+
     def _initialize_background(self):
         """Set up background state (zonal flow and PV gradients)."""
-        
+
         # Background zonal flow (m/s):
         self.H = self.Hi.sum()
         self.set_U1U2(self.U1, self.U2)
-        self.U = self.U1 - self.U2        
+        self.U = self.U1 - self.U2
 
         # the F parameters
         self.F1 = self.rd**-2 / (1.+self.delta)
@@ -131,21 +133,21 @@ class QGModel(model.Model):
         self.ikQy2 = self.Qy2 * 1j * self.k
 
         # vector version
-        self.ikQy = np.vstack([self.ikQy1[np.newaxis,...], 
-                               self.ikQy2[np.newaxis,...]]) 
+        self.ikQy = np.vstack([self.ikQy1[np.newaxis,...],
+                               self.ikQy2[np.newaxis,...]])
         self.ilQx = 0.
 
         # layer spacing
         self.del1 = self.delta/(self.delta+1.)
         self.del2 = (self.delta+1.)**-1
-        
+
     def _initialize_inversion_matrix(self):
-        
+
         # The matrix multiplication will look like this
         # ph[0] = a[0,0] * self.qh[0] + a[0,1] * self.qh[1]
         # ph[1] = a[1,0] * self.qh[0] + a[1,1] * self.qh[1]
 
-        a = np.ma.zeros((self.nz, self.nz, self.nl, self.nk), np.dtype('float64'))        
+        a = np.ma.zeros((self.nz, self.nz, self.nl, self.nk), np.dtype('float64'))
         # inverse determinant
         det_inv =  np.ma.masked_equal(
                 self.wv2 * (self.wv2 + self.F1 + self.F2), 0.)**-1
@@ -153,9 +155,9 @@ class QGModel(model.Model):
         a[0,1] = -self.F1*det_inv
         a[1,0] = -self.F2*det_inv
         a[1,1] = -(self.wv2 + self.F1)*det_inv
-        
+
         self.a = np.ma.masked_invalid(a).filled(0.)
-        
+
     def _initialize_forcing(self):
         pass
         #"""Set up frictional filter."""
@@ -164,13 +166,13 @@ class QGModel(model.Model):
         # wvx=np.sqrt((self.k*self.dx)**2.+(self.l*self.dy)**2.)
         # self.filtr = np.exp(-self.filterfac*(wvx-cphi)**4.)
         # self.filtr[wvx<=cphi] = 1.
-        
+
     def set_q1q2(self, q1, q2, check=False):
         """Set upper and lower layer PV anomalies.
-        
+
         Parameters
         ----------
-        
+
         q1 : array-like
             Upper layer PV anomaly in spatial coordinates.
         q1 : array-like
@@ -182,18 +184,18 @@ class QGModel(model.Model):
 
         # initialize spectral PV
         #self.qh = self.fft2(self.q)
-        
+
         # check that it works
         if check:
             np.testing.assert_allclose(self.q1, q1)
             np.testing.assert_allclose(self.q1, self.ifft2(self.qh1))
-    
+
     def set_U1U2(self, U1, U2):
         """Set background zonal flow.
-        
+
         Parameters
         ----------
-        
+
         U1 : number
             Upper layer flow. Units: m/s
         U2 : number
@@ -214,10 +216,10 @@ class QGModel(model.Model):
     #   (should also multiply by H1 and H2...)
     def _calc_ke(self):
         ke1 = .5*self.Hi[0]*self.spec_var(self.wv*self.ph[0])
-        ke2 = .5*self.Hi[1]*self.spec_var(self.wv*self.ph[1]) 
+        ke2 = .5*self.Hi[1]*self.spec_var(self.wv*self.ph[1])
         return ( ke1.sum() + ke2.sum() ) / self.H
 
-    # calculate eddy turn over time 
+    # calculate eddy turn over time
     # (perhaps should change to fraction of year...)
     def _calc_eddy_time(self):
         """ estimate the eddy turn-over time in days """
@@ -245,28 +247,28 @@ class QGModel(model.Model):
             function= (lambda self:
                       np.abs(self.del1*self.qh[0] + self.del2*self.qh[1])**2.)
         )
-            
+
         self.add_diagnostic('APEflux',
             description='spectral flux of available potential energy',
             function= (lambda self:
               self.rd**-2 * self.del1*self.del2 *
               np.real((self.ph[0]-self.ph[1])*np.conj(self.Jptpc)) )
         )
-        
+
         self.add_diagnostic('KEflux',
             description='spectral flux of kinetic energy',
             function= (lambda self:
-              np.real(self.del1*self.ph[0]*np.conj(self.Jpxi[0])) + 
+              np.real(self.del1*self.ph[0]*np.conj(self.Jpxi[0])) +
               np.real(self.del2*self.ph[1]*np.conj(self.Jpxi[1])) )
         )
-        
+
         self.add_diagnostic('APEgenspec',
             description='spectrum of APE generation',
             function= (lambda self: self.U * self.rd**-2 * self.del1 * self.del2 *
                        np.real(1j*self.k*(self.del1*self.ph[0] + self.del2*self.ph[0]) *
                                   np.conj(self.ph[0] - self.ph[1])) )
         )
-        
+
         self.add_diagnostic('APEgen',
             description='total APE generation',
             function= (lambda self: self.U * self.rd**-2 * self.del1 * self.del2 *
@@ -275,10 +277,10 @@ class QGModel(model.Model):
                             np.conj(self.ph[0] - self.ph[1])).sum()
                               +(1j*self.k[:,1:-2]*
                             (self.del1*self.ph[0,:,1:-2] + self.del2*self.ph[1,:,1:-2]) *
-                            np.conj(self.ph[0,:,1:-2] - self.ph[1,:,1:-2])).sum()) / 
+                            np.conj(self.ph[0,:,1:-2] - self.ph[1,:,1:-2])).sum()) /
                             (self.M**2) )
         )
-        
+
         ### These generic diagnostics are now calculated in model.py ###
         # self.add_diagnostic('KE1spec',
         #     description='upper layer kinetic energy spectrum',
@@ -316,5 +318,3 @@ class QGModel(model.Model):
         #                (self.del2*self.rek*self.wv2*
         #                 np.abs(self.ph[1])**2./(self.nx*self.ny)).sum())
         # )
-
-

--- a/pyqg/sqg_model.py
+++ b/pyqg/sqg_model.py
@@ -1,11 +1,12 @@
+from __future__ import print_function
 import numpy as np
-import model
 from numpy import pi
+from . import model
 
 
 class SQGModel(model.Model):
     """Surface quasigeostrophic model."""
-    
+
     def __init__(
         self,
         beta=0.,                    # gradient of coriolis parameter
@@ -36,38 +37,38 @@ class SQGModel(model.Model):
         self.H = H
         self.U = U
         #self.filterfac = filterfac
-        
+
         self.nz = 1
-       
+
         super(SQGModel, self).__init__(**kwargs)
-     
+
         # initial conditions: (PV anomalies)
         self.set_q(1e-3*np.random.rand(1,self.ny,self.nx))
- 
+
     ### PRIVATE METHODS - not meant to be called by user ###
-        
+
     def _initialize_background(self):
         """Set up background state (zonal flow and PV gradients)."""
-        
+
         # the meridional PV gradients in each layer
         self.Qy = np.asarray(self.beta)[np.newaxis, ...]
 
         # background vel.
-        self.set_U(self.U)        
+        self.set_U(self.U)
 
         # complex versions, multiplied by k, speeds up computations to pre-compute
         self.ikQy = self.Qy * 1j * self.k
-        
+
         self.ilQx = 0.
 
     def _initialize_inversion_matrix(self):
-        """ the inversion """ 
+        """ the inversion """
         # The sqg model is diagonal. The inversion is simply qh = -kappa**2 ph
         self.a = np.asarray(self.Nb*np.sqrt(self.wv2i))[np.newaxis, np.newaxis, :, :]
 
     def _initialize_forcing(self):
         pass
-    
+
     def set_U(self, U):
         """Set background zonal flow"""
         self.Ubg = np.asarray(U)[np.newaxis,...]
@@ -88,7 +89,7 @@ class SQGModel(model.Model):
         ke = .5*self.spec_var(self.wv*self.ph)
         return ke.sum()
 
-    # calculate eddy turn over time 
+    # calculate eddy turn over time
     # (perhaps should change to fraction of year...)
     def _calc_eddy_time(self):
         """ estimate the eddy turn-over time in days """

--- a/pyqg/tests/test_advection.py
+++ b/pyqg/tests/test_advection.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import numpy as np
 import pyqg
 
 def test_advect(rtol=1.e-13):
-    """ Make sure advective term vanishes for plane wave 
+    """ Make sure advective term vanishes for plane wave
         It is an unpleasant fact that we cannot to get
-        a double precision accuracy when the plane wave is 
+        a double precision accuracy when the plane wave is
         slanted (kx != 0 and ky !=0 ) """
 
     #m = bt_model.BTModel(L=2.*np.pi,nx=256)
@@ -23,7 +24,7 @@ def test_advect(rtol=1.e-13):
         # set plane wave PV
         #m.set_q(
         #        np.cos( kx[i] * m.x + ky[i] * m.y ))
-        
+
         m.set_q1q2(
                 np.cos( kx[i] * m.x + ky[i] * m.y ),
                 np.zeros_like(m.x) )
@@ -44,7 +45,7 @@ def test_advect(rtol=1.e-13):
         # residual -- the L2-norm of the jacobian
         res = np.abs(jacob).sum()*m.dx*m.dy/(m.L**2)
 
-        print "residual = %1.5e" %res
+        print("residual = %1.5e" %res)
 
         assert res<rtol, " *** Jacobian residual is larger than %1.1e" %rtol
 

--- a/pyqg/tests/test_fft2.py
+++ b/pyqg/tests/test_fft2.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import unittest
 import pyqg
@@ -8,7 +9,7 @@ class ModelFFTMixin:
     def test_parseval(self, rtol=1.e-15):
         """ Make sure 2D fft satisfies Parseval's relation
                 within machine double precision """
-        
+
         # set random stream function
         p1 = np.random.randn(self.m.nz, self.m.ny, self.m.nx)
         p1 -= p1.mean(axis=(-2,-1))[:,np.newaxis,np.newaxis]
@@ -16,39 +17,39 @@ class ModelFFTMixin:
         ph1 = self.m.fft(p1)
 
         # var(P) from Fourier coefficients
-        P_var_spec = spec_var(self.m, ph1) 
-        #print "Variance from spectrum: %5.16f" % P_var_spec
+        P_var_spec = spec_var(self.m, ph1)
+        #print("Variance from spectrum: %5.16f" % P_var_spec)
 
         # var(P) in physical space
         P_var_phys = p1.var(axis=(-2,-1))
-        #print "Variance in physical space: %5.16f" %P_var_phys
+        #print("Variance in physical space: %5.16f" % P_var_phys)
 
         # relative error
         error = np.abs((P_var_phys - P_var_spec)/P_var_phys).sum()
-        print "error = %5.16f" %error
+        print("error = %5.16f" %error)
 
         self.assertTrue(error<rtol,
                 "fft does not satisfy Parseval's relation")
-                
+
     def test_forward_backward(self, rtol=1e-5):
         """Test that forward and backward transform give the right result"""
-        
+
         r = np.random.randn(self.m.nz, self.m.ny, self.m.nx)
         r -= r.mean(axis=(-2,-1))[:,np.newaxis,np.newaxis]
         rh = self.m.fft(r)
         rf = self.m.ifft(rh)
         self.assertTrue(np.allclose(r, rf, rtol=rtol))
-                
+
 class BTModelFFTTester(ModelFFTMixin, unittest.TestCase):
-    
+
     def setUp(self):
         self.m = pyqg.BTModel(L=2.*np.pi, beta=0., U=0., rd=0., filterfac=0)
-        
+
 class QGModelFFTTester(ModelFFTMixin, unittest.TestCase):
-    
+
     def setUp(self):
         self.m = pyqg.QGModel(L=2.*np.pi, beta=0., U1=0., U2=0., filterfac=0.)
-    
+
 
 if __name__ == "__main__":
     test_parseval()

--- a/pyqg/tests/test_fftw.py
+++ b/pyqg/tests/test_fftw.py
@@ -1,8 +1,16 @@
 import numpy as np
 from numpy import pi
 import time
-import pyfftw
+import pytest
 
+# hack to skip tests if we don't have pyfft
+try:
+    import pyfftw
+    skip=False
+except ImportError:
+    skip=True
+
+@pytest.mark.skipif(skip, reason="Can't test fftw without pyfftw")
 def test_fftw_rfft2(Nx = 64, Ny = None, n = 7200):
     """ A verification of rfft2/irfft2 pyfftw accuracy lost... """
 
@@ -29,6 +37,7 @@ def test_fftw_rfft2(Nx = 64, Ny = None, n = 7200):
     print("Relative error after %i Forward/Inverse FFTs = %e " %(n,rel_err))
     print(" ")
 
+@pytest.mark.skipif(skip, reason="Can't test fftw without pyfftw")
 def test_fftw_rfft(Nx = 64, n = 100000):
     """ A verification of rfft/irfft accuracy lost """
 

--- a/pyqg/tests/test_fftw.py
+++ b/pyqg/tests/test_fftw.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 from numpy import pi
 import time

--- a/pyqg/tests/test_import.py
+++ b/pyqg/tests/test_import.py
@@ -1,7 +1,0 @@
-def test_answer():
-    import numpy
-    #import mkl
-    import pyfftw
-    import pyqg
-
-

--- a/pyqg/tests/test_layered.py
+++ b/pyqg/tests/test_layered.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest
 import numpy as np
 import pyqg
@@ -8,31 +9,31 @@ class LayeredModelTester(unittest.TestCase):
 
         self.m = pyqg.LayeredModel(
                     nz = 3,
-                    U  = [.1,.05,.0],                    
-                    V  = [.1,.05,.0],                    
+                    U  = [.1,.05,.0],
+                    V  = [.1,.05,.0],
                     rho= [.1,.3,.5],
                     H  = [.1,.1,.3],
                     f  = 1.,
                     beta = 0.)
-       
+
         self.atol=1.e-16
 
         # creates stretching matrix from scratch
         self.S = np.zeros((self.m.nz,self.m.nz))
-        
+
         F11 = self.m.f2/self.m.gpi[0]/self.m.Hi[0]
         F12 = self.m.f2/self.m.gpi[0]/self.m.Hi[1]
         F22 = self.m.f2/self.m.gpi[1]/self.m.Hi[1]
         F23 = self.m.f2/self.m.gpi[1]/self.m.Hi[2]
 
-        self.S[0,0], self.S[0,1] = -F11, F11 
+        self.S[0,0], self.S[0,1] = -F11, F11
         self.S[1,0], self.S[1,1], self.S[1,2] = F12, -(F12+F22), F22
         self.S[2,1], self.S[2,2] = F23, -F23
 
     def test_stretching(self):
-        """ Check if stretching matrix is consistent 
+        """ Check if stretching matrix is consistent
                 and satisfies basic properties """
- 
+
         # the columns of the S must add to zero (i.e, S is singular)
         err_msg = ' Zero is not an eigenvalue of S'
         assert np.all(self.m.S.sum(axis=1)==0.) , err_msg
@@ -44,13 +45,13 @@ class LayeredModelTester(unittest.TestCase):
 
         np.testing.assert_allclose(self.m.S,self.S,atol=self.atol,
                 err_msg= ' Unmatched stretching matrix')
-  
+
     def test_init_background(self):
         """ Check the initialization of the mean PV gradiends  """
 
         Qy = -np.einsum('ij,j->i',self.S,self.m.Ubg)
         Qx = np.einsum('ij,j->i',self.S,self.m.Vbg)
-        
+
         np.testing.assert_allclose(Qy,self.m.Qy,atol=self.atol,
                 err_msg=' Unmatched Qy')
         np.testing.assert_allclose(Qx,self.m.Qx,atol=self.atol,

--- a/pyqg/tests/test_model.py
+++ b/pyqg/tests/test_model.py
@@ -1,27 +1,28 @@
+from __future__ import print_function
 import unittest
 import numpy as np
 import pyqg
 
 class PyqgModelTester(unittest.TestCase):
-    
+
     def setUp(self):
         # need to eliminate beta and U for tests
         self.m = pyqg.QGModel(beta=0., U1=0., U2=0., filterfac=0.)
         # the maximum wavelengths to use in tests
         # if we go to higher wavelengths, we don't get machine precision
-        self.kwavemax = self.m.nx/8
-        self.lwavemax = self.m.ny/8
-    
+        self.kwavemax = int(self.m.nx/8)
+        self.lwavemax = int(self.m.ny/8)
+
     def test_fft2(self, rtol=1e-15):
         """Check whether pyqg fft functions produce the expected results."""
         # define a field with a known Fourier transform
         # if I go higher than a factor of 8, the tests start failing
         for kwave in range(1, self.kwavemax):
             for lwave in range(1, self.lwavemax):
-                
+
                 k = 2*np.pi*kwave/self.m.L
                 l = 2*np.pi*lwave/self.m.W
-                
+
                 # check whether these are the correct wavenumbers
                 np.testing.assert_allclose(self.m.kk[kwave], k, rtol,
                     err_msg='Incorrect wavenumber (kwave=%g)' % kwave)
@@ -29,20 +30,20 @@ class PyqgModelTester(unittest.TestCase):
                     err_msg='Incorrect wavenumber (lwave=%g)' % lwave)
                 np.testing.assert_allclose(self.m.ll[-lwave], -l, rtol,
                     err_msg='Incorrect wavenumber (lwave=%g)' % lwave)
-                
-                
+
+
                 q1 = np.cos(k * self.m.x )
                 q2 = np.sin(l * self.m.y)
-    
+
                 # assign it to the PV - FFT should also get taken at this point
                 self.m.set_q1q2(q1, q2)
-        
+
                 # amplitude of RFFT
                 qhamp = np.real(self.m.qh * self.m.qh.conj())
-        
+
                 # expected amplitude of RFFT
                 amp = (self.m.nx/2)**2 * self.m.ny**2
-        
+
                 # only have one Fourier component for k-axis
                 np.testing.assert_allclose(qhamp[0,0,kwave], amp, rtol,
                     err_msg='Incorrect wave amplitude from FFT (kwave=%g)' % kwave)
@@ -51,61 +52,61 @@ class PyqgModelTester(unittest.TestCase):
                     err_msg='Incorrect wave amplitude from FFT (lwave=%g)' % lwave)
                 np.testing.assert_allclose(qhamp[1,-lwave,0], amp, rtol,
                     err_msg='Incorrect wave amplitude from FFT (lwave=%g)' % lwave)
-                    
+
                 # now mask those components
                 qhamp_mask = np.ma.masked_array(qhamp, np.zeros_like(qhamp))
                 qhamp_mask.mask[0,0,kwave] = 1
                 qhamp_mask.mask[1,lwave,0] = 1
-                qhamp_mask.mask[1,-lwave,0] = 1                
+                qhamp_mask.mask[1,-lwave,0] = 1
                 # and make sure everything else is zero
                 np.testing.assert_allclose(qhamp_mask.filled(0.), 0.,
                     rtol=0., atol=rtol,
                     err_msg='Incorrect wave amplitude from FFT')
-                    
+
 
     def test_inversion_barotropic(self, rtol=1e-13):
         """Check whether inverting a barotropic PV gives desired result.
-        Can't get it to work with rtol < 1e-13 """ 
+        Can't get it to work with rtol < 1e-13 """
         # for barotropic, $q = \nabla^2 \psi$
         #                 $\hat{q} = -(k^2 + l^2) \hat \psi$
         #
         # velocity: u = -dpsi/dy, v = dpsi/dx
-                
+
         for kwave in range(1, self.kwavemax):
             for lwave in range(1, self.lwavemax):
 
                 k = 2*np.pi*kwave/self.m.L
                 l = 2*np.pi*lwave/self.m.W
-        
+
                 q =  np.cos(k * self.m.x ) + np.sin(l * self.m.y)
                 psi = -k**-2 * np.cos(k * self.m.x ) - l**-2 * np.sin(l * self.m.y)
                 u = l**-1 * np.cos(l * self.m.y)
                 v = k**-1 * np.sin(k * self.m.x)
-        
+
                 self.m.set_q1q2(q, q)
                 self.m._invert()
-        
+
                 for nz in range(self.m.nz):
                     np.testing.assert_allclose(self.m.u[nz], u, rtol,
                         err_msg='Incorrect velocity from barotropic pv inversion')
 
                     np.testing.assert_allclose(self.m.v[nz], v, rtol,
                         err_msg='Incorrect velocity from barotropic pv inversion')
-                        
+
     def test_inversion_baroclinic(self, rtol=1e-13):
         """Check whether inverting a baroclinic PV gives desired result."""
         # need to think about how to implement this
         pass
-        
+
     def test_advection(self, rtol=1e-15):
         """Check whether calculating advection tendency gives the descired result."""
         # sin(2 a) = 2 sin(a) cos(a)
-        
+
         for kwave in range(1, self.kwavemax):
             for lwave in range(1, self.lwavemax):
                 k = 2*np.pi*kwave/self.m.L
                 l = 2*np.pi*lwave/self.m.W
-        
+
                 q1 =  np.cos(k * self.m.x )
                 q2 =  np.sin(l * self.m.y )
                 self.m.set_q1q2(q1, q2)
@@ -119,12 +120,12 @@ class PyqgModelTester(unittest.TestCase):
                 self.m.u[1] = u2
                 self.m.v[1] = v2
                 self.m.set_U1U2(0.,0.)
-        
+
                 # calculate tendency
                 #self.m._advection_tendency()
                 self.m._do_advection()
                 dqhdt_adv = self.m.dqhdt
-        
+
                 # expected amplitude of RFFT
                 amp = (self.m.nx/2)**2 * self.m.ny**2
                 tabs = np.real(dqhdt_adv * dqhdt_adv.conj())
@@ -136,12 +137,12 @@ class PyqgModelTester(unittest.TestCase):
                     err_msg='Incorrect advection tendency +l (%g,%g)' % (lwave,kwave))
                 np.testing.assert_allclose(tabs[1,-2*lwave,0], l**2 * amp, rtol,
                     err_msg='Incorrect advection tendency -l (%g,%g)' % (lwave,kwave))
-            
+
                 # now mask those components
                 tabs_mask = np.ma.masked_array(tabs, np.zeros_like(tabs))
                 tabs_mask.mask[0,0,2*kwave] = 1
                 tabs_mask.mask[1,2*lwave,0] = 1
-                tabs_mask.mask[1,-2*lwave,0] = 1  
+                tabs_mask.mask[1,-2*lwave,0] = 1
                 # and make sure everything else is zero
                 np.testing.assert_allclose(tabs_mask.filled(0.), 0.,
                     rtol=0., atol=rtol,
@@ -150,12 +151,12 @@ class PyqgModelTester(unittest.TestCase):
     def test_friction(self, rtol=1e-15):
         """Check whether calculating advection tendency gives the expected result."""
         # sin(2 a) = 2 sin(a) cos(a)
-        
+
         for kwave in range(1, self.kwavemax):
             for lwave in range(1, self.lwavemax):
                 k = 2*np.pi*kwave/self.m.L
                 l = 2*np.pi*lwave/self.m.W
-        
+
                 q1 =  np.cos(k * self.m.x )
                 q2 =  np.sin(l * self.m.y )
                 self.m.set_q1q2(q1, q2)
@@ -163,8 +164,8 @@ class PyqgModelTester(unittest.TestCase):
                 # make sure tendency is zero
                 self.m.dqhdt[:] = 0.
                 self.m._do_friction()
-                
-                # from code 
+
+                # from code
                 #self.dqhdt[-1] += self.rek * self.wv2 * self.ph[-1]
                 expected = self.m.rek * self.m.wv2 * self.m.ph[-1]
                 np.testing.assert_allclose(self.m.dqhdt[-1], expected, rtol,
@@ -172,19 +173,19 @@ class PyqgModelTester(unittest.TestCase):
                 np.testing.assert_allclose(self.m.dqhdt[:-1], 0., rtol,
                         err_msg='Nonzero friction found in upper layers.')
 
-                    
+
     def test_timestepping(self, rtol=1e-15):
         """Make sure timstepping works properly."""
-        
+
         # set initial conditions to zero
         self.m.set_q(np.zeros_like(self.m.q))
-        
+
         # create a random tendency
         dqhdt = np.random.rand(*self.m.dqhdt.shape) + 1j*np.random.rand(*self.m.dqhdt.shape)
         self.m.dqhdt[:] = dqhdt
         # hack filter to be constant
         #self.m.filtr = 1.
-        
+
         # make sure we are at the zero timestep
         self.assertEqual(self.m.tc, 0)
         # step forward first time (should use forward Euler)
@@ -199,8 +200,8 @@ class PyqgModelTester(unittest.TestCase):
         self.m._forward_timestep()
         np.testing.assert_allclose(self.m.qh, 3*self.m.dt*dqhdt,
             err_msg='Third timestep incorrect')
-        
-        
-        
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/pyqg/tests/test_particles.py
+++ b/pyqg/tests/test_particles.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from builtins import range
 import unittest
 import numpy as np
 import pyqg
@@ -6,11 +8,11 @@ def constant_velocity_function(u, v):
     """Return a function that returns a constant velocity field."""
     return (lambda x, y: (u, v))
 
-    
+
 def solid_body_rotation_velocity_function(om):
     """Return a function that returns solid body rotation at angular
     velocity om."""
-    
+
     def sbr(x0, y0, om0):
         r = np.sqrt(x0**2 + y0**2)
         umag = om0 * r
@@ -18,20 +20,20 @@ def solid_body_rotation_velocity_function(om):
         u = umag * np.sin(a)
         v = -umag * np.cos(a)
         return u, v
-        
+
     return lambda x, y: sbr(x, y, om)
 
 class ParticleTester(unittest.TestCase):
-    
+
     def setUp(self):
         pass
-                    
+
     def test_integration(self, rtol=1e-14, atol=1e-10):
         """Check whether timestepping of particles produces the expected results."""
-        
+
         x0 = np.array([1.,-1])
         y0 = np.array([0.,0.])
-        
+
         # define a simple constant velocity field
         DT = 10.  # total time interval
         nt = 100  # number of time steps
@@ -41,16 +43,16 @@ class ParticleTester(unittest.TestCase):
                 # compute analytical solution
                 x1 = x0 + DT*u
                 y1 = y0 + DT*v
-                
+
                 uvfun = constant_velocity_function(u, v)
                 lpa = pyqg.LagrangianParticleArray2D(x0, y0)
-                for n in xrange(nt):
+                for n in range(nt):
                     lpa.step_forward_with_function(uvfun, uvfun, dt)
-                    
+
                 # check solution
                 np.testing.assert_allclose(x1, lpa.x, rtol=rtol)
                 np.testing.assert_allclose(y1, lpa.y, rtol=rtol)
-                
+
         # solid body rotation field
         nt = 1000
         for om in [0.1, 1., 10.]:
@@ -58,21 +60,21 @@ class ParticleTester(unittest.TestCase):
             T = 2*np.pi/om
             # pick a timestep
             dt = T / nt
-            
+
             uvfun = solid_body_rotation_velocity_function(om)
             lpa = pyqg.LagrangianParticleArray2D(x0, y0)
-            for n in xrange(nt):
+            for n in range(nt):
                 lpa.step_forward_with_function(uvfun, uvfun, dt)
-                
+
             # particles should be back to the same place
             np.testing.assert_allclose(
                 np.array([lpa.x, lpa.y]),
                 np.array([x0, y0]),
                 atol=atol
             )
-    
+
     def test_interpolation(self, rtol=1e-14, atol=1e-7):
-        
+
         # set up grid
         Lx = 10.
         Ly = 5.
@@ -86,12 +88,12 @@ class ParticleTester(unittest.TestCase):
         yg = np.arange(Ny)*dy + dy/2
         xxg, yyg = np.meshgrid(xg, yg)
         xxc, yyc = np.meshgrid(xc, yc)
-        
+
         # test field to interpolate
         ffun = lambda x, y: np.sin(2*np.pi*x/Lx)*np.sin(2*np.pi*y/Ly)
         f_at_g = ffun(xxg, yyg)
         f_at_c = ffun(xxc, yyc)
-        
+
         Npart = 10
         x0 = np.array(np.random.rand(Npart)*Lx)
         y0 = np.array(np.random.rand(Npart)*Ly)
@@ -99,11 +101,11 @@ class ParticleTester(unittest.TestCase):
              x0, y0, Nx, Ny,
              xmin=0, xmax=Lx, ymin=0, ymax=Ly,
              periodic_in_x=True, periodic_in_y=True)
-            
+
         # check if we interpolate back to the same points, we get same result
         f_at_gi = glpa.interpolate_gridded_scalar(xxg, yyg, f_at_g)
         np.testing.assert_allclose(f_at_g, f_at_gi)
-        
+
         # now try shifting everything
         # used to use cubic interpolation by default
         # that was slow and produced weird artifacts near boundaries
@@ -112,7 +114,7 @@ class ParticleTester(unittest.TestCase):
         # neglect of curvature causes velocity to be systematically underestimated
         f_at_ci = glpa.interpolate_gridded_scalar(xxc, yyc, f_at_g)
         np.testing.assert_allclose(f_at_c, f_at_ci, atol=1e-1)
-        
+
         # now try some random points
         # what sort of error do we expect
         ci = ffun(x0, y0)
@@ -120,9 +122,9 @@ class ParticleTester(unittest.TestCase):
             glpa.interpolate_gridded_scalar(x0, y0, f_at_g),
             atol=1e-1
         )
-        
+
     def test_gridded_integration(self, atol=1e-10):
-        
+
         # set up grid
         Lx = 4.
         Ly = 4.
@@ -138,11 +140,11 @@ class ParticleTester(unittest.TestCase):
         yg = xc + dy/2
         xxg, yyg = np.meshgrid(xg, yg)
         xxc, yyc = np.meshgrid(xc, yc)
-        
+
         # initial particle positions
         x0 = np.array([1.,-1])
         y0 = np.array([0.,0.])
-        
+
         # solid body rotation field
         nt = 1000
         for om in [0.1, 1., 10.]:
@@ -150,29 +152,29 @@ class ParticleTester(unittest.TestCase):
             T = 2*np.pi/om
             # pick a timestep
             dt = T / nt
-            
+
             uvfun = solid_body_rotation_velocity_function(om)
             u_at_g, v_at_g = uvfun(xxg, yyg)
             glpa = pyqg.GriddedLagrangianParticleArray2D(
                  x0, y0, Nx, Ny,
                  xmin=-Lx/2, xmax=Lx/2, ymin=-Ly/2, ymax=Ly/2,
                  periodic_in_x=True, periodic_in_y=True)
-                 
-            for n in xrange(nt):
+
+            for n in range(nt):
                 glpa.step_forward_with_gridded_uv(
                     u_at_g, v_at_g, u_at_g, v_at_g, dt)
-                
+
             # particles should be back to the same place
             np.testing.assert_allclose(
                 np.array([glpa.x, glpa.y]),
                 np.array([x0, y0]),
                 atol=atol
             )
-        
-        
-        
-        
-            
+
+
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyqg/tests/test_reference_solns.py
+++ b/pyqg/tests/test_reference_solns.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from future.utils import iteritems
 import unittest
 import numpy as np
 import pyqg
@@ -10,36 +12,36 @@ class ReferenceSolutionsTester(unittest.TestCase):
 
         year = 360*86400.
         m = pyqg.QGModel(
-            nx=32,                      
-            L=1e6,                      
-            beta=1.5e-11,               
-            rek=5.787e-7,               
-            rd=30000.0,                 
-            delta=0.25,                 
-            U1=0.05,                    
-            U2=0.0,                     
+            nx=32,
+            L=1e6,
+            beta=1.5e-11,
+            rek=5.787e-7,
+            rd=30000.0,
+            delta=0.25,
+            U1=0.05,
+            U2=0.0,
             filterfac=18.4,
-            dt=12800.,                   
-            tmax=3*year,          
-            tavestart=1*year,     
+            dt=12800.,
+            tmax=3*year,
+            tavestart=1*year,
             taveint=12800.,
             useAB2=True,
-            diagnostics_list='all'     
+            diagnostics_list='all'
             )
 
         m.set_q1q2(
                 (1e-6*np.cos(2*5*np.pi * m.x / m.L) +
                  1e-7*np.cos(2*5*np.pi * m.y / m.W)),
                 np.zeros_like(m.x) )
-                    
+
         m.run()
 
-        q1 = m.q[0] 
+        q1 = m.q[0]
         q1norm = (q1**2).sum()
 
         assert m.t == 93312000.0
-   
-        
+
+
         # machine + numpy.version fluctuations
         #   appears to be less than 0.1%
         rtol, atol = 0.01, 0.
@@ -50,7 +52,7 @@ class ReferenceSolutionsTester(unittest.TestCase):
 
         diagnostic_results = {
                 'APEgen': 2.5225558013107688e-07  / (m.nx**2),
-                'EKEdiss': 1.4806764171539711e-07 / (m.nx**2),                  
+                'EKEdiss': 1.4806764171539711e-07 / (m.nx**2),
                }
 
         sum_diagnostic_results = {
@@ -64,32 +66,32 @@ class ReferenceSolutionsTester(unittest.TestCase):
               'KEflux':  0.00037067750708912918,
               'APEgenspec': 0.00025837684260178754,
               'KEspec': 2 * (8581.3114357188006 + 163.75201433878425) / (m.M**2)
-        }    
+        }
 
- 
+
         # first print all output
-        for name, des in diagnostic_results.iteritems():
+        for name, des in iteritems(diagnostic_results):
             res = m.get_diagnostic(name)
-            print '%10s: %1.15e \n%10s  %1.15e (desired)' % (name, res, '', des)
-        for name, des in sum_diagnostic_results.iteritems():
+            print('%10s: %1.15e \n%10s  %1.15e (desired)' % (name, res, '', des))
+        for name, des in iteritems(sum_diagnostic_results):
             res = m.get_diagnostic(name).sum()
-            print '%10s: %1.15e \n%10s  %1.15e (desired)' % (name, res, '', des)
-        for name, des in avg_diagnostic_results.iteritems():
+            print('%10s: %1.15e \n%10s  %1.15e (desired)' % (name, res, '', des))
+        for name, des in iteritems(avg_diagnostic_results):
             res = diag.spec_sum(np.abs(m.get_diagnostic(name))).sum()
-            print '%10s: %1.15e \n%10s  %1.15e (desired)' % (name, res, '', des)
+            print('%10s: %1.15e \n%10s  %1.15e (desired)' % (name, res, '', des))
 
         # now do assertions
-        for name, des in diagnostic_results.iteritems():
+        for name, des in iteritems(diagnostic_results):
             res = m.get_diagnostic(name)
             np.testing.assert_allclose(res, des, rtol=rtol, atol=atol)
-        for name, des in sum_diagnostic_results.iteritems():
+        for name, des in iteritems(sum_diagnostic_results):
             res = m.get_diagnostic(name).sum()
-            np.testing.assert_allclose(res, des, rtol=rtol, atol=atol) 
-        for name, des in avg_diagnostic_results.iteritems():
+            np.testing.assert_allclose(res, des, rtol=rtol, atol=atol)
+        for name, des in iteritems(avg_diagnostic_results):
             res = diag.spec_sum(np.abs(m.get_diagnostic(name))).sum()
             np.testing.assert_allclose(res, des, rtol=rtol, atol=atol)
 
-        
+
     def test_bt(self):
         """ Tests against some statistics of a reference barotropic solution """
 
@@ -107,7 +109,7 @@ class ReferenceSolutionsTester(unittest.TestCase):
         qih = -m.wv2*pih
         qi = m.ifft(qih)
         m.set_q(qi)
-       
+
         rtol = 1.e-5
         atol = 1.e-14
 
@@ -120,9 +122,9 @@ class ReferenceSolutionsTester(unittest.TestCase):
         pnorm = (mp**2).sum()
         ke = m._calc_ke()
 
-        print 'time:       %g' % m.t
+        print('time:       %g' % m.t)
         assert m.t == 5.000000000000082
-        
+
         np.testing.assert_allclose(qnorm, 89101.741238768518, rtol, atol,
                 err_msg= ' Inconsistent with reference solution')
         np.testing.assert_allclose(pnorm, 1493.217664248918, rtol, atol,
@@ -160,9 +162,9 @@ class ReferenceSolutionsTester(unittest.TestCase):
         pnorm = (mp**2).sum()
         ke = m._calc_ke()
 
-        print 'time:       %g' % m.t
+        print('time:       %g' % m.t)
         assert m.t == 5.000000000000082
-        
+
         np.testing.assert_allclose(qnorm, 7847.5169609881032, rtol, atol,
                 err_msg= ' Inconsistent with reference solution')
         np.testing.assert_allclose(pnorm, 1346.8874163575524, rtol, atol,

--- a/pyqg/tests/test_vertical_modes.py
+++ b/pyqg/tests/test_vertical_modes.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest
 import numpy as np
 import pyqg
@@ -8,14 +9,14 @@ class VerticalModesTester(unittest.TestCase):
 
         self.m = pyqg.LayeredModel(
                     nz = 2,
-                    U  = [.1,.05],                    
-                    V  = [.1,.0],                    
+                    U  = [.1,.05],
+                    V  = [.1,.0],
                     H  = [1.,1.],
                     delta = 1.,
                     rd = 5.,
                     f  = 1.,
                     beta = 0.,)
-       
+
         self.atol=1.e-16
 
         self.m.set_q(np.random.randn(self.m.nz,self.m.ny,self.m.nx))
@@ -25,7 +26,7 @@ class VerticalModesTester(unittest.TestCase):
     def test_radii(self):
         """ Check deformation radii are computed correctly """
 
-        
+
         radii = np.array([self.m.g*self.m.H/np.abs(self.m.f), self.m.rd])
         np.testing.assert_allclose(self.m.radii,radii,atol=self.atol,
                 err_msg=' Wrong deformation radii')
@@ -35,7 +36,7 @@ class VerticalModesTester(unittest.TestCase):
 
         p = (self.m.Hi[:,np.newaxis]*self.m.pmodes)/self.m.H
 
-        print p
+        print(p)
 
         # barotropic mode must be depth invariant
         np.testing.assert_allclose(p[0,0],p[1,0],atol=self.atol,

--- a/setup.py
+++ b/setup.py
@@ -64,19 +64,19 @@ install_requires = [
 
 # This hack tells cython whether pyfftw is present
 use_pyfftw_file = 'pyqg/.compile_time_use_pyfftw.pxi'
-with open(use_pyfftw_file, 'w') as f:
+with open(use_pyfftw_file, 'wb') as f:
     try:
         import pyfftw
-        f.write('DEF PYQG_USE_PYFFTW = 1')
+        f.write(b'DEF PYQG_USE_PYFFTW = 1')
     except ImportError:
-        f.write('DEF PYQG_USE_PYFFTW = 0')
+        f.write(b'DEF PYQG_USE_PYFFTW = 0')
         warnings.warn('Could not import pyfftw. Model will be slow.')
 
 # check for openmp following
 # http://stackoverflow.com/questions/16549893/programatically-testing-for-openmp-support-from-a-python-setup-script
 # see http://openmp.org/wp/openmp-compilers/
 omp_test = \
-r"""
+br"""
 #include <omp.h>
 #include <stdio.h>
 int main() {
@@ -84,6 +84,8 @@ int main() {
 printf("Hello from thread %d, nthreads %d\n", omp_get_thread_num(), omp_get_num_threads());
 }
 """
+
+# python 3 needs rb
 
 def check_for_openmp():
     tmpdir = tempfile.mkdtemp()
@@ -94,12 +96,12 @@ def check_for_openmp():
         cc = os.environ['CC']
     except KeyError:
         cc = 'gcc'
-    with open(filename, 'w', 0) as file:
+    with open(filename, 'wb', 0) as file:
         file.write(omp_test)
-    with open(os.devnull, 'w') as fnull:
+    with open(os.devnull, 'wb') as fnull:
         result = subprocess.call([cc, '-fopenmp', filename],
                                  stdout=fnull, stderr=fnull)
-    print 'check_for_openmp() result: ', result
+    print('check_for_openmp() result: ', result)
     os.chdir(curdir)
     #clean up
     shutil.rmtree(tmpdir)
@@ -122,7 +124,7 @@ else:
 #if on_rtd:
 #    install_requires.remove('pyfftw')
 
-tests_require = ['nose']
+tests_require = ['pytest']
 
 def readme():
     with open('README.md') as f:

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ def readme():
         return f.read()
 
 ext_module = Extension(
-    "pyqg/kernel",
+    "pyqg.kernel",
     ["pyqg/kernel.pyx"],
     extra_compile_args=extra_compile_args,
     extra_link_args=extra_link_args,


### PR DESCRIPTION
With this PR, the tests pass in python 2.7 and 3.5. There may still be some residual non-python 3 compliant code floating around, but we won't find it until we improve the tests.

Fixes #129
Fixes #130 

(I think this supercedes #138)