### PR TITLE
Correct notation docs 2layer

### DIFF
--- a/benchmark/anirban_benchmark.py
+++ b/benchmark/anirban_benchmark.py
@@ -1,5 +1,0 @@
-import numpy as np
-import pyqg
-import time
-import cProfile
-import pstats

--- a/benchmark/anirban_benchmark.py
+++ b/benchmark/anirban_benchmark.py
@@ -1,0 +1,5 @@
+import numpy as np
+import pyqg
+import time
+import cProfile
+import pstats

--- a/docs/equations/notation_twolayer_model.rst
+++ b/docs/equations/notation_twolayer_model.rst
@@ -48,7 +48,7 @@ with the deformation wavenumber
 .. math::
 
 
-   k_d^2 \equiv\frac{f_0^2}{g}\frac{H_1+H_2}{H_1 H_2}\,,
+   k_d^2 \equiv\frac{f_0^2}{g'}\frac{H_1+H_2}{H_1 H_2}\,,
 
 where :math:`H = H_1 + H_2` is the total depth at rest.
 


### PR DESCRIPTION
$ k_d^2 \equiv\frac{f_0^2}{g}\frac{H_1+H_2}{H_1 H_2}\ $
corrected in docs/equations/notation_twolayer_model.rst to 
 $ k_d^2 \equiv\frac{f_0^2}{g'}\frac{H_1+H_2}{H_1 H_2}\ $
