### PR TITLE
Kernel refactor

### DIFF
--- a/pyqg/kernel.pyx
+++ b/pyqg/kernel.pyx
@@ -1,7 +1,7 @@
 #cython: profile=True
 #cython: boundscheck=False
 #cython: wraparound=False
-#cython: nonecheck=False 
+#cython: nonecheck=False
 #from __future__ import division
 import numpy as np
 import warnings
@@ -13,10 +13,10 @@ from cython.parallel import prange, threadid
 include '.compile_time_use_pyfftw.pxi'
 IF PYQG_USE_PYFFTW:
     import pyfftw
-    pyfftw.interfaces.cache.enable()  
+    pyfftw.interfaces.cache.enable()
 ELSE:
     import numpy.fft as npfft
-    warnings.warn('No pyfftw detected. Using numpy.fft') 
+    warnings.warn('No pyfftw detected. Using numpy.fft')
 
 # We now need to fix a datatype for our arrays. I've used the variable
 # DTYPE for this, which is assigned to the usual NumPy runtime
@@ -33,7 +33,7 @@ cdef class PseudoSpectralKernel:
     # array shapes
     cdef public int Nx, Ny, Nz
     cdef public int Nk, Nl
-    
+
     ### the main state variables (memory views to numpy arrays) ###
     # pv
     cdef DTYPE_real_t [:, :, :] q
@@ -54,13 +54,13 @@ cdef class PseudoSpectralKernel:
     cdef DTYPE_com_t [:, :, :] dqhdt
     cdef DTYPE_com_t [:, :, :] dqhdt_p
     cdef DTYPE_com_t [:, :, :] dqhdt_pp
-    
+
     # dummy variables for diagnostic ffts
     cdef DTYPE_real_t [:, :, :] _dummy_fft_in
     cdef DTYPE_com_t [:, :, :] _dummy_fft_out
     cdef DTYPE_real_t [:, :, :] _dummy_ifft_out
     cdef DTYPE_com_t [:, :, :] _dummy_ifft_in
-    
+
     # the variables needed for inversion and advection
     # store a as complex so we don't have to typecast in inversion
     cdef DTYPE_com_t [:, :, :, :] a
@@ -72,15 +72,15 @@ cdef class PseudoSpectralKernel:
     cdef DTYPE_com_t [:, :] _ikQy
     # spectral filter
     cdef public DTYPE_real_t [:, :] _filtr
-    
+
     # friction parameter
     cdef public DTYPE_real_t _rek
-    
+
     # time
     cdef public int tc
     cdef public DTYPE_real_t _dt
     cdef public DTYPE_real_t t
-    
+
     # threading
     cdef int num_threads
     # number of elements per work group in the y / l direction
@@ -95,79 +95,46 @@ cdef class PseudoSpectralKernel:
     cdef object fft_vq_to_vqh
     cdef object _dummy_fft
     cdef object _dummy_ifft
-        
-    def _kernel_init(self, int Nz, int Ny, int Nx, 
-                    np.ndarray[DTYPE_real_t, ndim=4] a,
-                    np.ndarray[DTYPE_real_t, ndim=1] k,
-                    np.ndarray[DTYPE_real_t, ndim=1] l,
-                    np.ndarray[DTYPE_real_t, ndim=1] Ubg,
-                    np.ndarray[DTYPE_real_t, ndim=1] Qy,
-                    np.ndarray[DTYPE_real_t, ndim=2] filtr,
-                    DTYPE_real_t dt=1.0,
-                    DTYPE_real_t rek=0.0,
-                    fftw_num_threads=1,                                       
-    ):
+
+    # refactor requires us to __cinit__ everything
+    # that we can just assign directly to the variables using properties
+    def __init__(self, int Nz, int Ny, int Nx, int fftw_num_threads=1):
         self.Nz = Nz
         self.Ny = Ny
         self.Nx = Nx
         self.Nl = Ny
         self.Nk = Nx/2 + 1
-        
-        self._rek = rek
-        
-        ### none of this shape checking works
-        #assert a.shape == (self.Nz, self.Nz self.Nl, self.Nk):
-        #assert k.shape == (self.Nk,):
-        #assert l.shape == (self.Nl,):
-        #assert Ubg.shape == (self.Nz,), 'Ubg is the wrong shape'
-        #assert Vbg.shape == (self.Nz,), 'Vbg is the wrong shape'
-        #assert Qx.shape == (self.Nz,), 'Qx is the wrong shape'
-        #assert Qy.shape == (self.Nz,), 'Qy is the wrong shape'
-        
-        # assign a, _ik, _il
-        self.a = a.astype(DTYPE_com)
-        self._ik = 1j*k
-        self._il = 1j*l
-        
+        self.a = np.zeros((self.Nz, self.Nz, self.Nl, self.Nk), DTYPE_com)
         self._k2l2 = np.zeros((self.Nl, self.Nk), DTYPE_real)
-        for j in range(self.Nl):
-            for i in range(self.Nk):
-                self._k2l2[j,i] = k[i]**2 + l[j]**2
-        
-        # assign Ubg, Vbg, _ilQx, _ikQy
-        self.Ubg = Ubg
-        #self.Vbg = Vbg
-        self._ikQy = 1j * k[np.newaxis, :] * Qy[:, np.newaxis]
-        
         # initialize FFT inputs / outputs as byte aligned by pyfftw
         q = self._empty_real()
-        self.q = q # assign to memory view
+        self.q = q
         qh = self._empty_com()
         self.qh = qh
-        
+
         ph = self._empty_com()
         self.ph = ph
-        
+
         u = self._empty_real()
         self.u = u
         uh = self._empty_com()
         self.uh = uh
-        
+
         v = self._empty_real()
         self.v = v
         vh = self._empty_com()
         self.vh = vh
-        
+
         uq = self._empty_real()
         self.uq = uq
         uqh = self._empty_com()
         self.uqh = uqh
-        
+
         vq = self._empty_real()
         self.vq = vq
         vqh = self._empty_com()
         self.vqh = vqh
-        
+
         # dummy variables for diagnostic ffts
         dfftin = self._empty_real()
         self._dummy_fft_in = dfftin
@@ -177,24 +144,16 @@ cdef class PseudoSpectralKernel:
         self._dummy_ifft_in = difftin
         difftout = self._empty_real()
         self._dummy_ifft_out = difftout
-        
+
         # the tendency
         self.dqhdt = self._empty_com()
         self.dqhdt_p = self._empty_com()
         self.dqhdt_pp = self._empty_com()
-        
-        # spectral filter
-        self._filtr = filtr
-        
-        # time stuff
-        self._dt = dt
-        self.tc = 0
-        self.t = 0.0
-        
+
         # for threading
         self.num_threads = fftw_num_threads
         self.chunksize = self.Nl/self.num_threads
-        
+
         IF PYQG_USE_PYFFTW:
             # set up FFT plans
             # Note that the Backwards Real transform for the case
@@ -206,20 +165,57 @@ cdef class PseudoSpectralKernel:
                              direction='FFTW_FORWARD', axes=(-2,-1))
             self.ifft_qh_to_q = pyfftw.FFTW(qh, q, threads=fftw_num_threads,
                              direction='FFTW_BACKWARD', axes=(-2,-1))
-            self.ifft_uh_to_u = pyfftw.FFTW(uh, u, threads=fftw_num_threads, 
+            self.ifft_uh_to_u = pyfftw.FFTW(uh, u, threads=fftw_num_threads,
                              direction='FFTW_BACKWARD', axes=(-2,-1))
-            self.ifft_vh_to_v = pyfftw.FFTW(vh, v, threads=fftw_num_threads, 
+            self.ifft_vh_to_v = pyfftw.FFTW(vh, v, threads=fftw_num_threads,
                              direction='FFTW_BACKWARD', axes=(-2,-1))
-            self.fft_uq_to_uqh = pyfftw.FFTW(uq, uqh, threads=fftw_num_threads, 
+            self.fft_uq_to_uqh = pyfftw.FFTW(uq, uqh, threads=fftw_num_threads,
                              direction='FFTW_FORWARD', axes=(-2,-1))
-            self.fft_vq_to_vqh = pyfftw.FFTW(vq, vqh, threads=fftw_num_threads, 
+            self.fft_vq_to_vqh = pyfftw.FFTW(vq, vqh, threads=fftw_num_threads,
                              direction='FFTW_FORWARD', axes=(-2,-1))
             # dummy ffts for diagnostics
-            self._dummy_fft = pyfftw.FFTW(dfftin, dfftout, threads=fftw_num_threads, 
+            self._dummy_fft = pyfftw.FFTW(dfftin, dfftout, threads=fftw_num_threads,
                              direction='FFTW_FORWARD', axes=(-2,-1))
-            self._dummy_ifft = pyfftw.FFTW(difftin, difftout, threads=fftw_num_threads, 
+            self._dummy_ifft = pyfftw.FFTW(difftin, difftout, threads=fftw_num_threads,
                              direction='FFTW_BACKWARD', axes=(-2,-1))
-    
+
+    def _kernel_init(self,
+                    np.ndarray[DTYPE_real_t, ndim=1] k,
+                    np.ndarray[DTYPE_real_t, ndim=1] l,
+                    np.ndarray[DTYPE_real_t, ndim=1] Ubg,
+                    np.ndarray[DTYPE_real_t, ndim=1] Qy,
+                    np.ndarray[DTYPE_real_t, ndim=2] filtr,
+                    DTYPE_real_t dt=1.0,
+                    DTYPE_real_t rek=0.0,
+    ):
+
+        self._rek = rek
+        self._ik = 1j*k
+        self._il = 1j*l
+
+        for j in range(self.Nl):
+            for i in range(self.Nk):
+                self._k2l2[j,i] = k[i]**2 + l[j]**2
+
+        # assign Ubg, Vbg, _ilQx, _ikQy
+        self.Ubg = Ubg
+        #self.Vbg = Vbg
+        self._ikQy = 1j * k[np.newaxis, :] * Qy[:, np.newaxis]
+
+
+
+        # spectral filter
+        self._filtr = filtr
+
+        # time stuff
+        self._dt = dt
+        self.tc = 0
+        self.t = 0.0
+
+
+
+
+
     # otherwise define those functions using numpy
     IF PYQG_USE_PYFFTW==0:
         def fft_q_to_qh(self):
@@ -238,7 +234,7 @@ cdef class PseudoSpectralKernel:
             self._dummy_fft_out = npfft.rfftn(self._dummy_fft_in, axes=(-2,-1))
         def _dummy_ifft(self):
             self._dummy_ifft_out = npfft.irfftn(self._dummy_ifft_in, axes=(-2,-1))
-            
+
     def _empty_real(self):
         """Allocate a space-grid-sized variable for use with fftw transformations."""
         shape = (self.Nz, self.Ny, self.Ny)
@@ -246,7 +242,7 @@ cdef class PseudoSpectralKernel:
             return pyfftw.n_byte_align_empty(shape,
                                  pyfftw.simd_alignment, dtype=DTYPE_real)
         ELSE:
-            return np.empty(shape, dtype=DTYPE_real)            
+            return np.empty(shape, dtype=DTYPE_real)
 
     def _empty_com(self):
         """Allocate a Fourier-grid-sized variable for use with fftw transformations."""
@@ -256,7 +252,7 @@ cdef class PseudoSpectralKernel:
                                  pyfftw.simd_alignment, dtype=DTYPE_com)
         ELSE:
             return np.empty(shape, dtype=DTYPE_com)
-    
+
     def fft(self, np.ndarray[DTYPE_real_t, ndim=3] v):
         """"Generic FFT function for real grid-sized variables.
         Not used for actual model ffs."""
@@ -276,7 +272,7 @@ cdef class PseudoSpectralKernel:
         self._dummy_ifft()
         # return a copy of the output
         return np.asarray(self._dummy_ifft_out).copy()
-   
+
     # the only way to set q and qh
     def set_qh(self, np.ndarray[DTYPE_com_t, ndim=3] b):
         cdef  DTYPE_com_t [:, :, :] b_view = b
@@ -284,7 +280,7 @@ cdef class PseudoSpectralKernel:
         self.ifft_qh_to_q()
         # input might have been destroyed, have to re-assign
         self.qh[:] = b_view
-        
+
     def set_q(self, np.ndarray[DTYPE_real_t, ndim=3] b):
         cdef  DTYPE_real_t [:, :, :] b_view = b
         self.q[:] = b_view
@@ -303,16 +299,16 @@ cdef class PseudoSpectralKernel:
         # set ph to zero
         for k in range(self.Nz):
             for j in prange(self.Nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,  
+                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.Nk):
-                    self.ph[k,j,i] = (0. + 0.*1j) 
-                    
+                    self.ph[k,j,i] = (0. + 0.*1j)
+
         # invert qh to find ph
         for k2 in range(self.Nz):
             for k1 in range(self.Nz):
                 for j in prange(self.Nl, nogil=True, schedule='static',
-                          chunksize=self.chunksize,  
+                          chunksize=self.chunksize,
                           num_threads=self.num_threads):
                     for i in range(self.Nk):
                         self.ph[k2,j,i] = ( self.ph[k2,j,i] +
@@ -321,7 +317,7 @@ cdef class PseudoSpectralKernel:
         # calculate spectral velocities
         for k in range(self.Nz):
             for j in prange(self.Nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,  
+                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.Nk):
                     self.uh[k,j,i] = -self._il[j] * self.ph[k,j,i]
@@ -332,18 +328,18 @@ cdef class PseudoSpectralKernel:
             #self.ifft_qh_to_q() # necessary now that timestepping is inside kernel
             self.ifft_uh_to_u()
             self.ifft_vh_to_v()
-            
+
         return
-    
+
     def _do_advection(self):
         self.__do_advection()
-    
+
     cdef void __do_advection(self) nogil:
         ### algorithm
         # uq, vq = (u+Ubg)*q, (v+Vbg)*q
         # uqh, vqh, = fft(uq), fft(vq)
         # tend = kj*uqh + _ilQx*ph + lj*vqh + _ilQy*ph
-        
+
         # the output array: spectal representation of advective tendency
         #cdef np.ndarray tend = np.zeros((self.Nz, self.Nl, self.Nk), dtype=DTYPE_com)
 
@@ -352,7 +348,7 @@ cdef class PseudoSpectralKernel:
         # multiply to get advective flux in space
         for k in range(self.Nz):
             for j in prange(self.Ny, nogil=True, schedule='static',
-                      chunksize=self.chunksize,  
+                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.Nx):
                     self.uq[k,j,i] = (self.u[k,j,i]+self.Ubg[k]) * self.q[k,j,i]
@@ -366,7 +362,7 @@ cdef class PseudoSpectralKernel:
         # spectral divergence
         for k in range(self.Nz):
             for j in prange(self.Nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,  
+                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.Nk):
                     # overwrite the tendency, since the forcing gets called after
@@ -377,14 +373,14 @@ cdef class PseudoSpectralKernel:
 
     def _do_friction(self):
         self.__do_friction()
-    
+
     cdef void __do_friction(self) nogil:
         """Apply Ekman friction to lower layer tendency"""
         cdef Py_ssize_t k = self.Nz-1
         cdef Py_ssize_t j, i
         if self._rek:
             for j in prange(self.Nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,  
+                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.Nk):
                     self.dqhdt[k,j,i] = (
@@ -392,14 +388,14 @@ cdef class PseudoSpectralKernel:
                              (self._rek *
                              self._k2l2[j,i] *
                              self.ph[k,j,i]) )
-        return                            
-                        
+        return
+
     def _forward_timestep(self):
         """Step forward based on tendencies"""
         self.__forward_timestep()
 
     cdef void __forward_timestep(self) nogil:
-   
+
         #self.dqhdt = self.dqhdt_adv + self.dqhdt_forc
         cdef DTYPE_real_t dt1
         cdef DTYPE_real_t dt2
@@ -408,7 +404,7 @@ cdef class PseudoSpectralKernel:
         cdef DTYPE_com_t [:, :, :] qh_new
         with gil:
             qh_new = self.qh.copy()
-        
+
         # Note that Adams-Bashforth is not self-starting
         if self.tc==0:
             # forward euler
@@ -425,10 +421,10 @@ cdef class PseudoSpectralKernel:
             dt1 = 23./12.*self._dt
             dt2 = -16./12.*self._dt
             dt3 = 5./12.*self._dt
-            
+
         for k in range(self.Nz):
             for j in prange(self.Nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,  
+                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.Nk):
                     qh_new[k,j,i] = self._filtr[j,i] * (
@@ -441,29 +437,46 @@ cdef class PseudoSpectralKernel:
                     self.dqhdt_pp[k,j,i] = self.dqhdt_p[k,j,i]
                     self.dqhdt_p[k,j,i] = self.dqhdt[k,j,i]
                     #self.dqhdt[k,j,i] = 0.0
-        
+
         # do FFT of new qh
         with gil:
             self.ifft_qh_to_q() # this destroys qh, need to assign again
-        
+
         for k in range(self.Nz):
             for j in prange(self.Nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,  
+                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.Nk):
-                    self.qh[k,j,i] = qh_new[k,j,i]    
+                    self.qh[k,j,i] = qh_new[k,j,i]
 
         self.tc += 1
         self.t += self._dt
         return
-        
+
     # attribute aliases: return numpy ndarray views of memory views
+    property a:
+        def __get__(self):
+            return np.asarray(self.a)
+        # inversion matrix should be real
+        def __set__(self, np.ndarray[DTYPE_real_t, ndim=4] b):
+            cdef  DTYPE_com_t [:, :, :, :] b_view = b.astype(DTYPE_com)
+            self.a[:] = b_view
     property q:
         def __get__(self):
             return np.asarray(self.q)
+        def __set__(self, np.ndarray[DTYPE_real_t, ndim=3] b):
+            cdef  DTYPE_real_t [:, :, :] b_view = b
+            self.q[:] = b_view
+            self.fft_q_to_qh()
     property qh:
         def __get__(self):
             return np.asarray(self.qh)
+        def __set__(self, np.ndarray[DTYPE_com_t, ndim=3] b):
+            cdef  DTYPE_com_t [:, :, :] b_view = b
+            self.qh[:] = b_view
+            self.ifft_qh_to_q()
+            # input might have been destroyed, have to re-assign
+            self.qh[:] = b_view
     property dqhdt:
         def __get__(self):
             return np.asarray(self.dqhdt)
@@ -527,17 +540,4 @@ def tendency_ab3(DTYPE_real_t dt,
     cdef DTYPE_real_t DT1 = 23/12.*dt
     cdef DTYPE_real_t DT2 = -16/12.*dt
     cdef DTYPE_real_t DT3 = 5/12.*dt
-    return DT1 * dqdt + DT2 * dqdt_p + DT3 * dqdt_pp 
-    
-
-
-
-
-
-
-
-
-
-
-
-
+    return DT1 * dqdt + DT2 * dqdt_p + DT3 * dqdt_pp

--- a/pyqg/kernel.pyx
+++ b/pyqg/kernel.pyx
@@ -77,6 +77,7 @@ cdef class PseudoSpectralKernel:
     cdef DTYPE_com_t [:, :] _ikQy
 
     # spectral filter
+    # TODO: figure out if this really needs to be public
     cdef public DTYPE_real_t [:, :] filtr
 
     # friction parameter
@@ -256,18 +257,6 @@ cdef class PseudoSpectralKernel:
         # return a copy of the output
         return np.asarray(self._dummy_ifft_out).copy()
 
-    # the only way to set q and qh
-    def set_qh(self, np.ndarray[DTYPE_com_t, ndim=3] b):
-        cdef  DTYPE_com_t [:, :, :] b_view = b
-        self.qh[:] = b_view
-        self.ifft_qh_to_q()
-        # input might have been destroyed, have to re-assign
-        self.qh[:] = b_view
-
-    def set_q(self, np.ndarray[DTYPE_real_t, ndim=3] b):
-        cdef  DTYPE_real_t [:, :, :] b_view = b
-        self.q[:] = b_view
-        self.fft_q_to_qh()
 
     def _invert(self):
         self.__invert()

--- a/pyqg/layered_model.py
+++ b/pyqg/layered_model.py
@@ -114,13 +114,12 @@ class LayeredModel(model.Model):
         self.beta = beta
         self.rd = rd
         self.delta = delta
-        self.nz = nz
         self.Ubg = np.array(U)
         self.Vbg = np.array(V)
         self.Hi = np.array(H)
         self.rhoi = np.array(rho)
 
-        super(LayeredModel, self).__init__(**kwargs)
+        super(LayeredModel, self).__init__(nz=nz, **kwargs)
 
         self.vertical_modes()
 

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -20,28 +20,44 @@ class Model(PseudoSpectralKernel):
 
     Attributes
     ----------
-    q : real array
-        Potential vorticity in real space
-    qh : complex array
-        Potential vorticity in spectral space
-    ph : complex array
-        Streamfunction in spectral space
-    u, v : real arrays
-        Velocity anomaly components in real space
-    ufull, vfull : real arrays
-        Full velocity components in real space
-    uh, vh : complex arrays
-        Velocity anomaly components in spectral space
     nx, ny : int
-        Number of grid points in the x and y directions
+        Number of real space grid points in the `x`, `y` directions (cython)
+    nk, nl : int
+        Number of spectal space grid points in the `k`, `l` directions (cython)
+    nz : int
+        Number of vertical levels (cython)
+    kk, ll : real array
+        Zonal and meridional wavenumbers (`nk`) (cython)
+    ll : real array
+        meridional wavenumbers (`nl`) (cython)
+    a : real array
+        inversion matrix (`nk`, `nk`, `nl`, `nk`) (cython)
+    q : real array
+        Potential vorticity in real space (`nz`, `ny`, `nx`) (cython)
+    qh : complex array
+        Potential vorticity in spectral space (`nk`, `nl`, `nk`) (cython)
+    ph : complex array
+        Streamfunction in spectral space (`nk`, `nl`, `nk`) (cython)
+    u, v : real array
+        Zonal and meridional velocity anomalies in real space (`nz`, `ny`, `nx`) (cython)
+    Ubg : real array
+        Background zonal velocity (`nk`) (cython)
+    ufull, vfull : real arrays
+        Zonal and meridional full velocities in real space (`nz`, `ny`, `nx`) (cython)
+    uh, vh : complex arrays
+        Velocity anomaly components in spectral space (`nk`, `nl`, `nk`) (cython)
+    rek : float
+        Linear drag in lower layer (cython)
+    t : float
+        Model time (cython)
+    tc : int
+        Model timestep (cython)
+    dt : float
+        Numerical timestep (cython)
     L, W : float
         Domain length in x and y directions
-    rek : float
-        Linear drag in lower layer
     filterfac : float
         Amplitdue of the spectral spherical filter
-    dt : float
-        Numerical timstep
     twrite : int
         Interval for cfl writeout (units: number of timesteps)
     tmax : float
@@ -138,19 +154,15 @@ class Model(PseudoSpectralKernel):
             your machine.
         """
 
-        if ny is None: ny = nx
-        if W is None: W = L
+        if ny is None:
+            ny = nx
+        if W is None:
+            W = L
 
         # TODO: be more clear about what attributes are cython and what
         # attributes are python
         PseudoSpectralKernel.__init__(self, nz, ny, nx, ntd)
 
-        # put all the parameters into the object
-        # grid
-        # (This is redundant!)
-        self.nz = nz
-        self.nx = nx
-        self.ny = ny
         self.L = L
         self.W = W
 
@@ -163,9 +175,6 @@ class Model(PseudoSpectralKernel):
         self.logfile = logfile
         self.log_level = log_level
         self.useAB2 = useAB2
-        # fft
-        #self.use_fftw = use_fftw
-        #self.teststyle= teststyle
         self.ntd = ntd
 
         # friction
@@ -178,20 +187,18 @@ class Model(PseudoSpectralKernel):
             self.f = f
             self.f2 = f**2
 
-
+        # TODO: make this less complicated!
+        # Really we just need to initialize the grid here. It's not necessary
+        # to have all these silly methods. Maybe we need "hooks" instead.
         self._initialize_logger()
         self._initialize_grid()
         self._initialize_background()
         self._initialize_forcing()
         self._initialize_filter()
         self._initialize_time()
-
-        # call the underlying cython kernel
-        self._initialize_kernel()
-        # refactoring: need to start initializing kernel first
         self._initialize_inversion_matrix()
-
         self._initialize_diagnostics(diagnostics_list)
+
 
     def run_with_snapshots(self, tsnapstart=0., tsnapint=432000.):
         """Run the model forward, yielding to user code at specified intervals.
@@ -363,6 +370,7 @@ class Model(PseudoSpectralKernel):
         self.taveints = np.ceil(self.taveint/self.dt)
 
     ### initialization routines, only called once at the beginning ###
+    # TODO: clean up and simplify this whole routine
     def _initialize_grid(self):
         """Set up spatial and spectral grids and related constants"""
         self.x,self.y = np.meshgrid(
@@ -375,8 +383,9 @@ class Model(PseudoSpectralKernel):
         self.dl = 2.*pi/self.W
 
         # wavenumber grids
-        self.nl = self.ny
-        self.nk = int(self.nx/2+1)
+        # set in kernel
+        #self.nl = self.ny
+        #self.nk = int(self.nx/2+1)
         self.ll = self.dl*np.append( np.arange(0.,self.nx/2),
             np.arange(-self.nx/2,0.) )
         self.kk = self.dk*np.arange(0.,self.nk)
@@ -417,33 +426,15 @@ class Model(PseudoSpectralKernel):
         # this defines the spectral filter (following Arbic and Flierl, 2003)
         cphi=0.65*pi
         wvx=np.sqrt((self.k*self.dx)**2.+(self.l*self.dy)**2.)
-        self.filtr = np.exp(-self.filterfac*(wvx-cphi)**4.)
-        self.filtr[wvx<=cphi] = 1.
+        filtr = np.exp(-self.filterfac*(wvx-cphi)**4.)
+        filtr[wvx<=cphi] = 1.
+        self.filtr = filtr
 
     def _filter(self, q):
         return self.filtr * q
 
     def _do_external_forcing(self):
         pass
-
-    def _initialize_kernel(self):
-        #super(spectral_kernel.PseudoSpectralKernel, self).__init__(
-        self._kernel_init(
-            self.kk, self.ll,
-            self.Ubg, self.Qy,
-            self.filtr,
-            dt=self.dt,
-            rek=self.rek
-        )
-
-        # still need to initialize a few state variables here, outside kernel
-        # this is sloppy
-        #self.dqhdt_forc = np.zeros_like(self.qh)
-        #self.dqhdt_p = np.zeros_like(self.qh)
-        #self.dqhdt_pp = np.zeros_like(self.qh)
-
-        self.logger.info(' Kernel initialized')
-
 
     # logger
     def _initialize_logger(self):

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 import numpy as np
 from numpy import pi
 import logging
+import warnings
+
 from .kernel import PseudoSpectralKernel, tendency_forward_euler, tendency_ab2, tendency_ab3
 try:
     import mkl
@@ -28,8 +30,6 @@ class Model(PseudoSpectralKernel):
         Number of vertical levels (cython)
     kk, ll : real array
         Zonal and meridional wavenumbers (`nk`) (cython)
-    ll : real array
-        meridional wavenumbers (`nl`) (cython)
     a : real array
         inversion matrix (`nk`, `nk`, `nl`, `nk`) (cython)
     q : real array
@@ -42,6 +42,8 @@ class Model(PseudoSpectralKernel):
         Zonal and meridional velocity anomalies in real space (`nz`, `ny`, `nx`) (cython)
     Ubg : real array
         Background zonal velocity (`nk`) (cython)
+    Qy : real array
+        Background potential vorticity gradient (`nk`) (cython)
     ufull, vfull : real arrays
         Zonal and meridional full velocities in real space (`nz`, `ny`, `nx`) (cython)
     uh, vh : complex arrays
@@ -658,3 +660,15 @@ class Model(PseudoSpectralKernel):
         var_dens[...,0] = var_dens[...,0]/2.
         var_dens[...,-1] = var_dens[...,-1]/2.
         return var_dens.sum()
+
+
+    def set_qh(self, qh):
+        warnings.warn("Method deprecated. Set model.qh directly instead. ",
+            DeprecationWarning)
+        self.qh = qh
+
+
+    def set_q(self, q):
+        warnings.warn("Method deprecated. Set model.q directly instead. ",
+            DeprecationWarning)
+        self.q = q

--- a/pyqg/qg_model.py
+++ b/pyqg/qg_model.py
@@ -98,9 +98,8 @@ class QGModel(model.Model):
         self.U2 = U2
         #self.filterfac = filterfac
 
-        self.nz = 2
 
-        super(QGModel, self).__init__(**kwargs)
+        super(QGModel, self).__init__(nz=2, **kwargs)
 
         # initial conditions: (PV anomalies)
         self.set_q1q2(

--- a/pyqg/tests/test_model.py
+++ b/pyqg/tests/test_model.py
@@ -98,6 +98,13 @@ class PyqgModelTester(unittest.TestCase):
         # need to think about how to implement this
         pass
 
+    def test_change_inversion_matrix(self):
+        """Make sure we can change the inversion matrix after kernel has been
+        initialized."""
+        a_new = np.random.rand(self.m.Nz, self.m.Nz, self.m.Nl, self.m.Nk)
+        self.m.a = a_new
+        np.testing.assert_allclose(a_new, self.m.a)
+
     def test_advection(self, rtol=1e-15):
         """Check whether calculating advection tendency gives the descired result."""
         # sin(2 a) = 2 sin(a) cos(a)

--- a/pyqg/tests/test_model.py
+++ b/pyqg/tests/test_model.py
@@ -101,7 +101,7 @@ class PyqgModelTester(unittest.TestCase):
     def test_change_inversion_matrix(self):
         """Make sure we can change the inversion matrix after kernel has been
         initialized."""
-        a_new = np.random.rand(self.m.Nz, self.m.Nz, self.m.Nl, self.m.Nk)
+        a_new = np.random.rand(self.m.nz, self.m.nz, self.m.nl, self.m.nk)
         self.m.a = a_new
         np.testing.assert_allclose(a_new, self.m.a)
 
@@ -197,6 +197,8 @@ class PyqgModelTester(unittest.TestCase):
         self.assertEqual(self.m.tc, 0)
         # step forward first time (should use forward Euler)
         self.m._forward_timestep()
+        print('here')
+
         np.testing.assert_allclose(self.m.qh, 1*self.m.dt*dqhdt,
             err_msg='First timestep incorrect')
         # step forward second time (should use AB2)

--- a/pyqg/tests/test_model.py
+++ b/pyqg/tests/test_model.py
@@ -151,6 +151,8 @@ class PyqgModelTester(unittest.TestCase):
                 tabs_mask.mask[1,2*lwave,0] = 1
                 tabs_mask.mask[1,-2*lwave,0] = 1
                 # and make sure everything else is zero
+                if np.any(np.isnan(tabs_mask.filled(0.))):
+                    print("Found NaNs")
                 np.testing.assert_allclose(tabs_mask.filled(0.), 0.,
                     rtol=0., atol=rtol,
                     err_msg='Incorrect advection tendency (%g,%g)' % (lwave,kwave))
@@ -197,7 +199,6 @@ class PyqgModelTester(unittest.TestCase):
         self.assertEqual(self.m.tc, 0)
         # step forward first time (should use forward Euler)
         self.m._forward_timestep()
-        print('here')
 
         np.testing.assert_allclose(self.m.qh, 1*self.m.dt*dqhdt,
             err_msg='First timestep incorrect')


### PR DESCRIPTION
This is an attempt to roll back some of the unnecessary complexity that got added when I created the cython kernel. There were lots of duplicated attributes between the cython and python levels (e.g. `model.dt` vs. `model._dt`) that were making it hard to understand what is going on (see #144). 

The main thing happening here is the elimination of methods like `_kernel_init()` and `set_qh()` in favor of direct access to the cython-level model attributes. For example, to set the pv, you can now just say

```python
m.q = some_numpy_array
```

Or if you want to change the timestep, you can just do
```python
m.dt = 100
```
(note that this also resets the adams bashforth timestepping to start with a forward-Euler step)

I hope this is the first of several PRs to clean up and streamline the code, making it easier to move forward with the implementation of other new features.

cc: @crocha700 