### PR TITLE
Missing \kappa^2 in the PV equation

### DIFF
--- a/docs/equations/notation_equivalent_barotropic.rst
+++ b/docs/equations/notation_equivalent_barotropic.rst
@@ -24,6 +24,6 @@ The inversion relationship in Fourier space is
 .. math::
 
 
-   \hat{q} = -\left(\kappa + \kappa_d^2\right) \hat{\psi}\,.
+   \hat{q} = -\left(\kappa^2 + \kappa_d^2\right) \hat{\psi}\,.
 
 The system is marched forward in time similarly to the two-layer model.


### PR DESCRIPTION
Fixes typo in the potential vorticity anomaly equation in Fourier space: missing square on wavenumber \kappa.