### PR TITLE
fixes some typos in layered equations docs

### DIFF
--- a/docs/equations/notation_layered.rst
+++ b/docs/equations/notation_layered.rst
@@ -43,8 +43,8 @@ bottom topography, we obtain the evolution equations
 
    \begin{aligned}
    \label{eq:qg_dynamics}
-   {q_n}_t + \mathsf{J}(\psi_n,q_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_b )& + U_n ({q_n}_x + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_{bx}) + V_n ({q_n}_y + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_{by})+ \nonumber
-   \\ & {Q_n}_y {\psi_n}_x - {Q_n}_x {\psi_n}_y = {\text{ssd}}- r_{ek} \delta_{n{\mathrm{N}}} {\nabla^2}\psi_n {\, ,}\qquad n = 1,{\mathrm{N}}{\, ,}\end{aligned}
+   {q_n}_t + \mathsf{J}(\psi_n,q_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_b )& + U_n ({q_n}_x + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_{bx}) + V_n ({q_n}_y + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_{by}) \nonumber
+   \\ & + {Q_n}_y {\psi_n}_x - {Q_n}_x {\psi_n}_y = {\text{ssd}} - r_{ek} \delta_{n{\mathrm{N}}} {\nabla^2}\psi_n {\, ,}\qquad n = 1,{\mathrm{N}}{\, ,}\end{aligned}
 
 where :math:`{\text{ssd}}` is stands for small-scale dissipation, which
 is achieved by an spectral exponential filter or hyperviscosity, and
@@ -55,23 +55,23 @@ bottom layer. (Note that in QG :math:`h_b/H_{\mathrm{N}}<< 1`.)
 Equations in spectral space
 ---------------------------
 
-The evolutionary equation in spectral space is
+The evolution equation in spectral space is
 
 .. math::
 
    \begin{aligned}
-       \hat{q}_{nt} + (\mathrm{i} k U + \mathrm{i} l V) \left(\hat{q}_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}\hat{h}_b\right) + (\mathrm{i} k\, {Q_y} -  - \mathrm{i} l\,{Q_x}){\hat{\psi}_n} + \mathsf{\hat{J}}(\psi_n, q_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_b )   \nonumber \\ =  {\text{ssd}}+ \mathrm{i}  \delta_{n {\mathrm{N}}} r_{ek} \kappa^2 \hat{\psi}_n \,, \qquad i = 1,\textsf{N}{\, ,}\end{aligned}
+       \widehat{q}_{nt} + (\mathrm{i} k U + \mathrm{i} l V) \left(\widehat{q}_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}\widehat{h}_b\right) + (\mathrm{i} k\, {Q_y} - \mathrm{i} l\,{Q_x}){\widehat{\psi}_n} + \mathsf{\widehat{J}}(\psi_n, q_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_b )   \nonumber \\ =  {\text{ssd}} - \delta_{n {\mathrm{N}}} r_{ek} \kappa^2 \widehat{\psi}_n \,, \qquad i = 1,\textsf{N}{\, ,}\end{aligned}
 
 where :math:`\kappa^2 = k^2 + l^2`. Also, in the pseudo-spectral spirit
 we write the transform of the nonlinear terms and the non-constant
 coefficient linear term as the transform of the products, calculated in
 physical space, as opposed to double convolution sums. That is
-:math:`\mathsf{\hat{J}}` is the Fourier transform of Jacobian computed
+:math:`\mathsf{\widehat{J}}` is the Fourier transform of Jacobian computed
 in physical space.
 
 The inversion relationship is
 
-.. math:: \hat{q}_i = {\left({\mathsf{S}}- \kappa^2 {\mathsf{I}}\right)} \hat{\psi}_i{\, ,}
+.. math:: \widehat{q}_i = {\left({\mathsf{S}}- \kappa^2 {\mathsf{I}}\right)} \widehat{\psi}_i{\, ,}
 
 where :math:`{\mathsf{I}}` is the :math:`{\mathrm{N}}\times{\mathrm{N}}`
 identity matrix, and the stretching matrix is
@@ -95,16 +95,16 @@ Energy spectrum
 
 The equation for the energy spectrum,
 
-.. math:: E(k,l) \equiv {\frac{1}{2 H}\sum_{i=1}^{{\mathrm{N}}} H_i \kappa^2 |\hat{\psi}_i|^2} \,\,\,\,+ \,\,\,\,\,\, {\frac{1}{2 H} \sum_{i=1}^{{\mathrm{N}}-1} \frac{f_0^2}{g'_i}|\hat{\psi}_{i}- \hat{\psi}_{i+1}|^2}\,\,\,\,,
+.. math:: E(k,l) \equiv {\frac{1}{2 H}\sum_{i=1}^{{\mathrm{N}}} H_i \kappa^2 |\widehat{\psi}_i|^2} \,\,\,\,+ \,\,\,\,\,\, {\frac{1}{2 H} \sum_{i=1}^{{\mathrm{N}}-1} \frac{f_0^2}{g'_i}|\widehat{\psi}_{i}- \widehat{\psi}_{i+1}|^2}\,\,\,\,,
 
 is
 
 .. math::
 
    \begin{aligned}
-       \frac{d}{dt} E(k,l) = {\frac{1}{H}\sum_{i=1}^{\mathsf{N}} H_i \text{Re}[\hat{\psi}_i^\star {\mathsf{\hat{J}}}(\psi_i,\nabla^2\psi_i)]} +
-       {\frac{1}{H}\sum_{i=1}^{\mathsf{N}} H_i\text{Re}[\hat{\psi}_i^\star \hat{\mathsf{J} (\psi_i,({\mathsf{S}}\psi)_i)}]} \nonumber \\
-       + {\frac{1}{H}\sum_{i=1}^{\mathsf{N}} H_i ( k U_i +  l V_i)\, \text{Re}[i \, \hat{\psi}^\star_i (\mathsf{S}\hat{\psi}_i)]} \,\,\,\,\,\,\,{- r_{ek} \frac{H_\mathsf{N}}{H} \kappa^2 |\hat{\psi}_{\mathsf{N}}|^2}  +{ {{E_{\text{ssd}}}}} {\, ,}\end{aligned}
+       \frac{d}{dt} E(k,l) = {\frac{1}{H}\sum_{i=1}^{\mathsf{N}} H_i \text{Re}[\widehat{\psi}_i^\star {\mathsf{\widehat{J}}}(\psi_i,\nabla^2\psi_i)]} +
+       {\frac{1}{H}\sum_{i=1}^{\mathsf{N}} H_i\text{Re}[\widehat{\psi}_i^\star \widehat{\mathsf{J} (\psi_i,({\mathsf{S}}\psi)_i)}]} \nonumber \\
+       + {\frac{1}{H}\sum_{i=1}^{\mathsf{N}} H_i ( k U_i +  l V_i)\, \text{Re}[i \, \widehat{\psi}^\star_i (\mathsf{S}\widehat{\psi}_i)]} \,\,\,\,\,\,\,{- r_{ek} \frac{H_\mathsf{N}}{H} \kappa^2 |\widehat{\psi}_{\mathsf{N}}|^2}  +{ {{E_{\text{ssd}}}}} {\, ,}\end{aligned}
 
 where :math:`\star` stands for complex conjugation, and the terms above
 on the right represent, from left to right,
@@ -132,15 +132,15 @@ Enstrophy spectrum
 
 Similarly the evolution of the barotropic enstrophy spectrum,
 
-.. math:: Z(k,l) \equiv \frac{1}{2H} \sum_{i=1}^{{\mathrm{N}}} H_i |\hat{q}_i|^2{\, ,}
+.. math:: Z(k,l) \equiv \frac{1}{2H} \sum_{i=1}^{{\mathrm{N}}} H_i |\widehat{q}_i|^2{\, ,}
 
 is governed by
 
 .. math::
 
-   \frac{d}{d t} Z(k,l) = {\text{Re}[\hat{q}_i^\star {\mathsf{\hat{J}}(\psi_i,q_i) ]}}
-       {-(k Q_y - l Q_x)\text{Re}[({\mathsf{S}}\hat{\psi}_i^\star)\hat{\psi}_i]}
-       + { {\hat{Z_{\text{ssd}}}}}{\, ,}
+   \frac{d}{d t} Z(k,l) = {\text{Re}[\widehat{q}_i^\star {\mathsf{\widehat{J}}(\psi_i,q_i) ]}}
+       {-(k Q_y - l Q_x)\text{Re}[({\mathsf{S}}\widehat{\psi}_i^\star)\widehat{\psi}_i]}
+       + { {\widehat{Z_{\text{ssd}}}}}{\, ,}
 
 where the terms above on the right represent, from left to right,
 
@@ -192,8 +192,8 @@ The inversion relationship in Fourier space is
 .. math::
 
    \begin{bmatrix}
-   \hat{\psi}_1\\
-   \hat{\psi}_2\\
+   \widehat{\psi}_1\\
+   \widehat{\psi}_2\\
    \end{bmatrix}
    = \frac{1}{\text{det} \: {\mathsf{B}}}
    \begin{bmatrix}
@@ -201,8 +201,8 @@ The inversion relationship in Fourier space is
    \:\:\:\: -F_2 \qquad - (\kappa^2 + F_1)
    \end{bmatrix}
    \begin{bmatrix}
-   \hat{q}_1\\
-   \hat{q}_2\\
+   \widehat{q}_1\\
+   \widehat{q}_2\\
    \end{bmatrix}{\, ,}
 
 where

--- a/docs/equations/notation_layered.rst
+++ b/docs/equations/notation_layered.rst
@@ -9,13 +9,11 @@ is
    \begin{aligned}
    {q_1} &= {\nabla^2}\psi_1 + \frac{f_0^2}{H_1} \left(\frac{\psi_{2}-\psi_1}{g'_{1}}\right)\,,  \qquad & n =1{\, ,}\nonumber \\
    {q_n} &= {\nabla^2}\psi_n + \frac{f_0^2}{H_n} \left(\frac{\psi_{n-1}-\psi_n}{g'_{n-1}}  - \frac{\psi_{n}-\psi_{n+1}}{g'_{n}}\right)\,,  \qquad &n = 2,{\mathrm{N}}-1 {\, ,}\nonumber \\
-   {q_{\mathrm{N}}} &= {\nabla^2}\psi_{\mathrm{N}}+ \frac{f_0^2}{H_{\mathrm{N}}} \left(\frac{\psi_{\textsf{N}-1}-\psi_{\mathrm{N}}}{g'_{{\mathrm{N}}-1}}\right) + \frac{f_0}{H_{\mathrm{N}}}h_b (x,y)\,,  \qquad & n ={\mathrm{N}}\,,\end{aligned}
+   {q_{\mathrm{N}}} &= {\nabla^2}\psi_{\mathrm{N}}+ \frac{f_0^2}{H_{\mathrm{N}}} \left(\frac{\psi_{\textsf{N}-1}-\psi_{\mathrm{N}}}{g'_{{\mathrm{N}}-1}}\right) \,,  \qquad & n ={\mathrm{N}}\,,\end{aligned}
 
 where :math:`q_n` is the n’th layer QG potential vorticity, and
 :math:`\psi_n` is the streamfunction, :math:`f_0` is the inertial
-frequency, n’th :math:`H_n` is the layer depth, and :math:`h_b` is the
-bottom topography. (Note that in QG :math:`h_b/H_{\mathrm{N}}<< 1`.)
-Also the n’th buoyancy jump (reduced gravity) is
+frequency, :math:`H_n` is the layer depth. Also the n’th buoyancy jump (reduced gravity) is
 
 .. math:: g'_n \equiv g \frac{\rho_{n}-\rho_{n+1}}{\rho_n}{\, ,}
 
@@ -38,20 +36,21 @@ and
 .. math:: q_n^{{\text{tot}}} = Q_n + \delta_{n{\mathrm{N}}}\frac{f_0}{H_{\mathrm{N}}}h_b + q_n {\, ,}
 
 where :math:`Q_n + \delta_{n{\mathrm{N}}}\frac{f_0}{H_{\mathrm{N}}}h_b`
-is n’th layer background PV, we obtain the evolution equations
+is n’th layer background PV and :math:`h_b` is the
+bottom topography, we obtain the evolution equations
 
 .. math::
 
    \begin{aligned}
    \label{eq:qg_dynamics}
    {q_n}_t + \mathsf{J}(\psi_n,q_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_b )& + U_n ({q_n}_x + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_{bx}) + V_n ({q_n}_y + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_{by})+ \nonumber
-   \\ & {Q_n}_y {\psi_n}_x - {Q_n}_y {\psi_n}_y = {\text{ssd}}- r_{ek} \delta_{n{\mathrm{N}}} {\nabla^2}\psi_n {\, ,}\qquad n = 1,{\mathrm{N}}{\, ,}\end{aligned}
+   \\ & {Q_n}_y {\psi_n}_x - {Q_n}_x {\psi_n}_y = {\text{ssd}}- r_{ek} \delta_{n{\mathrm{N}}} {\nabla^2}\psi_n {\, ,}\qquad n = 1,{\mathrm{N}}{\, ,}\end{aligned}
 
-where :math:`{\text{ssd}}` is stands for small scale dissipation, which
+where :math:`{\text{ssd}}` is stands for small-scale dissipation, which
 is achieved by an spectral exponential filter or hyperviscosity, and
 :math:`r_{ek}` is the linear bottom drag coefficient. The Dirac delta,
 :math:`\delta_{nN}`, indicates that the drag is only applied in the
-bottom layer.
+bottom layer. (Note that in QG :math:`h_b/H_{\mathrm{N}}<< 1`.)
 
 Equations in spectral space
 ---------------------------
@@ -184,8 +183,8 @@ With this notation, the “stretching matrix” is simply
 .. math::
 
    {\mathsf{S}}= \begin{bmatrix}
-   - F_1 \qquad \:\:\:\:F_1\\
-   F_2 \qquad -  + F_2
+   - F_1 \qquad \:\:F_1\\
+   F_2 \qquad - F_2
    \end{bmatrix}{\, .}
 
 The inversion relationship in Fourier space is


### PR DESCRIPTION
Also, the topographic PV was in both `q_n` and `Q_n`; now it's only part of `Q_n`.