### PR TITLE
rbg should default to zero

### DIFF
--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -102,7 +102,7 @@ class Model(PseudoSpectralKernel):
         useAB2=False,               # use second order Adams Bashforth timestepping instead of 3rd
         # friction parameters
         rek=5.787e-7,               # linear drag in lower layer
-        rbg=5.787e-7,               # linear drag in each layer
+        rbg=0,                      # linear drag in each layer
         filterfac=23.6,             # the factor for use in the exponential filter
         # constants
         f = None,                   # coriolis parameter (not necessary for two-layer model


### PR DESCRIPTION
Prior to the updates for the zonal jet example, PyQG had no relaxation to the mean flow. The relaxation is controlled by the parameter `rbg` which defaults to `5.787e-7`. This leads to extra damping relative to the previous version for the same input parameters. In order to recover original behavior, `rbg` should default to zero. 