### PR TITLE
Some more doc/comments fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ experiments/
 
 # development environment
 .vscode/**
+
+# mac os x temp
+.DS_Store

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -8,13 +8,13 @@ Team
 
 - `Ryan Abernathey`_, Columbia University / LDEO
 
-- `Cesar Rocha`_, Scripps Institution of Oceanography / UCSD
+- `Cesar Rocha`_, Woods Hole Oceanographic Institution
 
 - `Francis Poulin`_, University of Waterloo
 
 .. _Malte Jansen: http://geosci.uchicago.edu/people/malte-jansen/
-.. _Ryan Abernathey: http://ryan.actualscience.net
-.. _Cesar Rocha: http://crocha700.github.io/
+.. _Ryan Abernathey: http://rabernat.github.io
+.. _Cesar Rocha: http://https://www.cbrocha.com
 .. _Francis Poulin: https://uwaterloo.ca/poulin-research-group/
 
 History
@@ -31,13 +31,13 @@ implemented a cython kernel. Cesar and Francis implemented the barotropic and
 sqg models.
 
 .. _WHOI GFD Summer School: https://www.whoi.edu/gfd/
-.. _Glenn Flierl: http://eaps-www.mit.edu/paoc/people/glenn-r-flierl
+.. _Glenn Flierl: https://eapsweb.mit.edu/people/grflierl
 
 Future
 ======
 
 By adopting open-source best practices, we hope pyqg will grow into a widely
-used, communited-based project. We know that many other research groups have
+used, communicated-based project. We know that many other research groups have
 their own "in house" QG models. You can get involved by trying out the model,
 filing issues_ if you find problems, and making `pull requests`_ if you make
 improvements.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -37,7 +37,7 @@ Future
 ======
 
 By adopting open-source best practices, we hope pyqg will grow into a widely
-used, communicated-based project. We know that many other research groups have
+used, community-based project. We know that many other research groups have
 their own "in house" QG models. You can get involved by trying out the model,
 filing issues_ if you find problems, and making `pull requests`_ if you make
 improvements.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -14,7 +14,7 @@ Team
 
 .. _Malte Jansen: http://geosci.uchicago.edu/people/malte-jansen/
 .. _Ryan Abernathey: http://rabernat.github.io
-.. _Cesar Rocha: http://https://www.cbrocha.com
+.. _Cesar Rocha: http://www.cbrocha.com
 .. _Francis Poulin: https://uwaterloo.ca/poulin-research-group/
 
 History

--- a/docs/equations/notation_equivalent_barotropic.rst
+++ b/docs/equations/notation_equivalent_barotropic.rst
@@ -24,6 +24,6 @@ The inversion relationship in Fourier space is
 .. math::
 
 
-   \hat{q} = -\left(\kappa^2 + \kappa_d^2\right) \hat{\psi}\,.
+   \widehat{q} = -\left(\kappa^2 + \kappa_d^2\right) \widehat{\psi}\,.
 
 The system is marched forward in time similarly to the two-layer model.

--- a/docs/equations/notation_layered.rst
+++ b/docs/equations/notation_layered.rst
@@ -8,12 +8,12 @@ is
 
    \begin{aligned}
    {q_1} &= {\nabla^2}\psi_1 + \frac{f_0^2}{H_1} \left(\frac{\psi_{2}-\psi_1}{g'_{1}}\right)\,,  \qquad & n =1{\, ,}\nonumber \\
-   {q_n} &= {\nabla^2}\psi_n + \frac{f_0^2}{H_n} \left(\frac{\psi_{n-1}-\psi_n}{g'_{n-1}}  - \frac{\psi_{n}-\psi_{n+1}}{g'_{n}}\right)\,,  \qquad &n = 2,{\mathrm{N}}-1 {\, ,}\nonumber \\
-   {q_{\mathrm{N}}} &= {\nabla^2}\psi_{\mathrm{N}}+ \frac{f_0^2}{H_{\mathrm{N}}} \left(\frac{\psi_{\textsf{N}-1}-\psi_{\mathrm{N}}}{g'_{{\mathrm{N}}-1}}\right) \,,  \qquad & n ={\mathrm{N}}\,,\end{aligned}
+   {q_n} &= {\nabla^2}\psi_n + \frac{f_0^2}{H_n} \left(\frac{\psi_{n-1}-\psi_n}{g'_{n-1}}  - \frac{\psi_{n}-\psi_{n+1}}{g'_{n}}\right)\,,  \qquad &n = 2,\dots,{\mathrm{N}}-1 {\, ,}\nonumber \\
+   {q_{\mathrm{N}}} &= {\nabla^2}\psi_{\mathrm{N}}+ \frac{f_0^2}{H_{\mathrm{N}}} \left(\frac{\psi_{\mathrm{N}-1}-\psi_{\mathrm{N}}}{g'_{{\mathrm{N}}-1}}\right) \,,  \qquad & n ={\mathrm{N}}\,,\end{aligned}
 
-where :math:`q_n` is the n’th layer QG potential vorticity, and
+where :math:`q_n` is the `n`-th layer QG potential vorticity, and
 :math:`\psi_n` is the streamfunction, :math:`f_0` is the inertial
-frequency, :math:`H_n` is the layer depth. Also the n’th buoyancy jump (reduced gravity) is
+frequency, :math:`H_n` is the layer depth. Also the `n`-th buoyancy jump (reduced gravity) is
 
 .. math:: g'_n \equiv g \frac{\rho_{n}-\rho_{n+1}}{\rho_n}{\, ,}
 
@@ -22,7 +22,7 @@ the layer density.
 
 The dynamics of the system is given by the evolution of PV. In
 particular, assuming a background flow with background velocity
-:math:`\vec{V} = (U,V)` such that
+:math:`\overrightarrow{V} = (U,V)` such that
 
 .. math::
 
@@ -36,7 +36,7 @@ and
 .. math:: q_n^{{\text{tot}}} = Q_n + \delta_{n{\mathrm{N}}}\frac{f_0}{H_{\mathrm{N}}}h_b + q_n {\, ,}
 
 where :math:`Q_n + \delta_{n{\mathrm{N}}}\frac{f_0}{H_{\mathrm{N}}}h_b`
-is n’th layer background PV and :math:`h_b` is the
+is `n`-th layer background PV and :math:`h_b` is the
 bottom topography, we obtain the evolution equations
 
 .. math::
@@ -44,13 +44,13 @@ bottom topography, we obtain the evolution equations
    \begin{aligned}
    \label{eq:qg_dynamics}
    {q_n}_t + \mathsf{J}(\psi_n,q_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_b )& + U_n ({q_n}_x + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_{bx}) + V_n ({q_n}_y + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_{by}) \nonumber
-   \\ & + {Q_n}_y {\psi_n}_x - {Q_n}_x {\psi_n}_y = {\text{ssd}} - r_{ek} \delta_{n{\mathrm{N}}} {\nabla^2}\psi_n {\, ,}\qquad n = 1,{\mathrm{N}}{\, ,}\end{aligned}
+   \\ & + {Q_n}_y {\psi_n}_x - {Q_n}_x {\psi_n}_y = {\text{ssd}} - r_{ek} \delta_{n{\mathrm{N}}} {\nabla^2}\psi_n {\, ,}\qquad n = 1,\dots,{\mathrm{N}}{\, ,}\end{aligned}
 
 where :math:`{\text{ssd}}` is stands for small-scale dissipation, which
 is achieved by an spectral exponential filter or hyperviscosity, and
 :math:`r_{ek}` is the linear bottom drag coefficient. The Dirac delta,
 :math:`\delta_{nN}`, indicates that the drag is only applied in the
-bottom layer. (Note that in QG :math:`h_b/H_{\mathrm{N}}<< 1`.)
+bottom layer. (Note that in QG :math:`h_b/H_{\mathrm{N}} \ll 1`.)
 
 Equations in spectral space
 ---------------------------
@@ -60,7 +60,7 @@ The evolution equation in spectral space is
 .. math::
 
    \begin{aligned}
-       \widehat{q}_{nt} + (\mathrm{i} k U + \mathrm{i} l V) \left(\widehat{q}_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}\widehat{h}_b\right) + (\mathrm{i} k\, {Q_y} - \mathrm{i} l\,{Q_x}){\widehat{\psi}_n} + \mathsf{\widehat{J}}(\psi_n, q_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_b )   \nonumber \\ =  {\text{ssd}} - \delta_{n {\mathrm{N}}} r_{ek} \kappa^2 \widehat{\psi}_n \,, \qquad i = 1,\textsf{N}{\, ,}\end{aligned}
+       \widehat{q}_{nt} + (\mathrm{i} k U + \mathrm{i} l V) \left(\widehat{q}_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}\widehat{h}_b\right) + (\mathrm{i} k\, {Q_y} - \mathrm{i} l\,{Q_x}){\widehat{\psi}_n} + \mathsf{\widehat{J}}(\psi_n, q_n + \delta_{n {\mathrm{N}}} \frac{f_0}{H_{\mathrm{N}}}h_b )   \nonumber \\ =  {\text{ssd}} + \delta_{n {\mathrm{N}}} r_{ek} \kappa^2 \widehat{\psi}_n \,, \qquad i = 1,\dots,\mathrm{N}{\, ,}\end{aligned}
 
 where :math:`\kappa^2 = k^2 + l^2`. Also, in the pseudo-spectral spirit
 we write the transform of the nonlinear terms and the non-constant
@@ -178,7 +178,7 @@ with the deformation wavenumber
 
 .. math:: k_d^2 \equiv \, \frac{f_0^2}{g} \frac{H_1+H_2}{H_1 H_2} {\, .}
 
-With this notation, the “stretching matrix” is simply
+With this notation, the stretching matrix is simply
 
 .. math::
 

--- a/docs/equations/notation_sqg_model.rst
+++ b/docs/equations/notation_sqg_model.rst
@@ -12,7 +12,7 @@ The evolution equation is
 .. math::
 
 
-   \partial_t b + J(\psi, b) = 0\,,  \qquad \text{at} \qquad z = 0\,,
+   \partial_t b + \mathsf{J}(\psi, b) = 0\,,  \qquad \text{at} \qquad z = 0\,,
 
 where :math:`b = \psi_z` is the buoyancy.
 
@@ -38,7 +38,7 @@ and
 .. math::
 
 
-   \psi = 0,  \qquad \text{at} \qquad z \rightarrow -\infty\,,
+   \psi = 0,  \qquad \text{at} \qquad z \rightarrow -\infty\,.
 
 The solutions to the elliptic problem above, in horizontal Fourier
 space, gives the inversion relationship between surface buoyancy and
@@ -47,7 +47,7 @@ surface streamfunction
 .. math::
 
 
-   \hat \psi = \frac{f_0}{N} \frac{1}{\kappa}\hat b\,,  \qquad \text{at} \qquad z = 0\,,
+   \widehat{\psi} = \frac{f_0}{N} \frac{1}{\kappa} \widehat{b}\,,  \qquad \text{at} \qquad z = 0\,.
 
 The SQG evolution equation is marched forward similarly to the two-layer
 model.

--- a/docs/equations/notation_twolayer_model.rst
+++ b/docs/equations/notation_twolayer_model.rst
@@ -19,7 +19,7 @@ and (2)
 where the horizontal Jacobian is
 :math:`\mathsf{J}\left(A\,, B\right) = A_x B_y - A_y B_x`. Also in (1)
 and (2) ssd denotes small-scale dissipation (in turbulence regimes, ssd
-absorbs enstrophy that cascates towards small scales). The linear bottom
+absorbs enstrophy that cascades towards small scales). The linear bottom
 drag in (2) dissipates large-scale energy.
 
 The potential vorticities are (3)
@@ -88,16 +88,16 @@ model. Fourier transforming the evolution equations (5) and (6) gives
 .. math::
 
 
-   \partial_t\,{\hat{q}_1} = - \hat{\mathsf{J}}\left(\psi_1\,, q_1\right) - \text{i}\,k\, \beta_1\, {\hat{\psi}_1} + \hat{\text{ssd}} \,,
+   \partial_t\,{\widehat{q}_1} = - \widehat{\mathsf{J}}\left(\psi_1\,, q_1\right) - \text{i}\,k\, \beta_1\, {\widehat{\psi}_1} + \widehat{\text{ssd}} \,,
 
 and
 
 .. math::
 
 
-   \partial_t\,{\hat{q}_2} = - \hat{\mathsf{J}}\left(\psi_2\,, q_2\right)-  \text{i}\,k\, \beta_2\, {\hat{\psi}_2}  + r_{ek}\,\kappa^2\,\, \hat{\psi}_2 + \hat{\text{ssd}}\,,
+   \partial_t\,{\widehat{q}_2} = - \widehat{\mathsf{J}}\left(\psi_2\,, q_2\right)-  \text{i}\,k\, \beta_2\, {\widehat{\psi}_2}  + r_{ek}\,\kappa^2\,\, \widehat{\psi}_2 + \widehat{\text{ssd}}\,,
 
-where, in the pseudo-spectral spirit, :math:`\hat{\mathsf{J}}` means the
+where, in the pseudo-spectral spirit, :math:`\widehat{\mathsf{J}}` means the
 Fourier transform of the Jacobian i.e., we compute the products in
 physical space, and then transform to Fourier space.
 
@@ -108,15 +108,15 @@ In Fourier space the "inversion relation" (3)-(4) is
 
    \underbrace{\begin{bmatrix}
    -(\kappa^2 + F_1) \qquad \:\:\:\:F_1\\
-   \:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:F_2 \qquad - (\kappa^2 + F_2)
+   \:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:F_2 \qquad - (\kappa^2 + F_2)\;
    \end{bmatrix}}_{\equiv \,\mathsf{M_2}}
    \begin{bmatrix}
-   \hat{\psi}_1\\
-   \hat{\psi}_2\\
+   \widehat{\psi}_1\\
+   \widehat{\psi}_2\\
    \end{bmatrix}
    =\begin{bmatrix}
-   \hat{q}_1\\
-   \hat{q}_2\\
+   \widehat{q}_1\\
+   \widehat{q}_2\\
    \end{bmatrix}
    \,,
 
@@ -126,17 +126,17 @@ or equivalently
 
 
    \begin{bmatrix}
-   \hat{\psi}_1\\
-   \hat{\psi}_2\\
+   \widehat{\psi}_1\\
+   \widehat{\psi}_2\\
    \end{bmatrix}
    =\underbrace{\frac{1}{\text{det}\,\mathrm{M_2}}
    \begin{bmatrix}
    -(\kappa^2 + F_2) \qquad \:\:\:\:-F_1\\
-   \:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:-F_2 \qquad - (\kappa^2 + F_1)
+   \:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:-F_2 \qquad - (\kappa^2 + F_1)\;
    \end{bmatrix}}_{=\,\mathsf{M_2}^{-1}}
    \begin{bmatrix}
-   \hat{q}_1\\
-   \hat{q}_2\\
+   \widehat{q}_1\\
+   \widehat{q}_2\\
    \end{bmatrix}
    \,,\qquad
 
@@ -155,28 +155,28 @@ We use a third-order Adams-Bashford scheme
 .. math::
 
 
-   {\hat{q}_i}^{n+1} = E_f\times\left[{\hat{q}_i}^{n} + \frac{\Delta t}{12}\left(23\, \hat{Q}_i^{n} -  16\hat{Q}_i^{n-1} + 5 \hat{Q}_i^{n-2}\right)\right]\,,
+   {\widehat{q}_i}^{n+1} = E_f\times\left[{\widehat{q}_i}^{n} + \frac{\Delta t}{12}\left(23\, \widehat{Q}_i^{n} -  16\widehat{Q}_i^{n-1} + 5 \widehat{Q}_i^{n-2}\right)\right]\,,
 
 where
 
 .. math::
 
 
-   \hat{Q}_i^n \equiv - \hat{\mathsf{J}}\left(\psi_i^n\,, q_i^n\right) - \text{i}\,k\, \beta_i\, {\hat{\psi}_i^n}, \qquad i = 1,2\,.
+   \widehat{Q}_i^n \equiv - \widehat{\mathsf{J}}\left(\psi_i^n\,, q_i^n\right) - \text{i}\,k\, \beta_i\, {\widehat{\psi}_i^n}, \qquad i = 1,2\,.
 
 The AB3 is initialized with a first-order AB (or forward Euler)
 
 .. math::
 
 
-   {\hat{q}_i}^{1} = E_f\times\left[{\hat{q}_i}^{0} + \Delta t \hat{Q}_i^{0}\right]\,,
+   {\widehat{q}_i}^{1} = E_f\times\left[{\widehat{q}_i}^{0} + \Delta t \widehat{Q}_i^{0}\right]\,,
 
 The second step uses a second-order AB scheme
 
 .. math::
 
 
-   {\hat{q}_i}^{2} = E_f\times\left[{\hat{q}_i}^{1} + \frac{\Delta t}{2}\left(3\, \hat{Q}_i^{1} -  \hat{Q}_i^0\right)\right]\,.
+   {\widehat{q}_i}^{2} = E_f\times\left[{\widehat{q}_i}^{1} + \frac{\Delta t}{2}\left(3\, \widehat{Q}_i^{1} -  \widehat{Q}_i^0\right)\right]\,.
 
 The small-scale dissipation is achieve by a highly-selective exponential
 filter
@@ -206,7 +206,7 @@ whithin machine double precision:
 
    \frac{\log 10^{-15}}{(0.35\, \pi)^4} \approx -23.5\,.
 
-For experiments with :math:`|\hat{q_i}|<<\mathcal{O}(1)` one can use a
+For experiments with :math:`|\widehat{q_i}|\ll\mathcal{O}(1)` one can use a
 smaller constant.
 
 Diagnostics
@@ -217,7 +217,7 @@ The kinetic energy is
 .. math::
 
 
-   E = \tfrac{1}{H\,S} \int  \tfrac{1}{2} H_1 \, |\nabla \psi_1|^2 +  \tfrac{1}{2} H_2 \, |\nabla \psi_2|^2 \, d S\,.
+   E = \tfrac{1}{H\,S} \int  \tfrac{1}{2} H_1 \, |\boldsymbol{\nabla} \psi_1|^2 +  \tfrac{1}{2} H_2 \, |\boldsymbol{\nabla} \psi_2|^2 \, d S\,.
 
 The potential enstrophy is
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ pyqg: Python Quasigeostrophic Model
 
 pyqg is a python solver for quasigeostrophic systems. Quasigeostophic
 equations are an approximation to the full fluid equations of motion in
-the limit of strong rotation and stratitifcation and are most applicable
+the limit of strong rotation and stratification and are most applicable
 to geophysical fluid dynamics problems.
 
 Students and researchers in ocean and atmospheric dynamics are the intended

--- a/pyqg/bt_model.py
+++ b/pyqg/bt_model.py
@@ -35,7 +35,7 @@ class BTModel(model.Model):
         rd : number, optional
             Deformation radius. Units: meters.
         U : number *or* array-like, optional
-            Upper layer flow. Units: meters.
+            Upper layer flow. Units: meters seconds :sup:`-1`.
         """
 
         self.beta = beta
@@ -98,7 +98,7 @@ class BTModel(model.Model):
         ----------
 
         U : number *or* array-like
-            Upper layer flow. Units meters.
+            Upper layer flow. Units meters seconds :sup:`-1`.
         """
         self.Ubg = np.asarray(U)[np.newaxis, ...]
 

--- a/pyqg/kernel.pyx
+++ b/pyqg/kernel.pyx
@@ -330,7 +330,7 @@ cdef class PseudoSpectralKernel:
         # uqh, vqh, = fft(uq), fft(vq)
         # tend = kj*uqh + _ilQx*ph + lj*vqh + _ilQy*ph
 
-        # the output array: spectal representation of advective tendency
+        # the output array: spectral representation of advective tendency
         #cdef np.ndarray tend = np.zeros((self.nz, self.nl, self.nk), dtype=DTYPE_com)
 
         cdef Py_ssize_t k, j, i

--- a/pyqg/layered_model.py
+++ b/pyqg/layered_model.py
@@ -73,12 +73,12 @@ class LayeredModel(model.Model):
     def __init__(
         self,
         g = 9.81,
-        beta=1.5e-11,               # gradient of coriolis parameter
+        beta = 1.5e-11,             # gradient of coriolis parameter
         nz = 4,                     # number of layers
-        rd=15000.0,                 # deformation radius
+        rd = 15000.0,               # deformation radius
         H = None,                   # layer thickness
-        U=None,                     # zonal base state flow
-        V=None,                     # meridional base state flow
+        U = None,                   # zonal base state flow
+        V = None,                   # meridional base state flow
         rho = None,
         delta = None,
         **kwargs
@@ -99,9 +99,9 @@ class LayeredModel(model.Model):
             Layer thickness ratio (H1/H2). Only necessary for the
             two-layer (nz=2) case. Unitless.
         U : list of size nz *or* list of size nz by ny
-            Base state zonal velocity. Units: meters s :sup:`-1`
+            Base state zonal velocity. Units: meters seconds :sup:`-1`
         V : array of size nz *or* list of size nz by ny
-            Base state meridional velocity. Units: meters s :sup:`-1`
+            Base state meridional velocity. Units: meters seconds :sup:`-1`
         H : array of size nz
             Layer thickness. Units: meters
         rho: array of size nz.

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -473,7 +473,7 @@ class Model(PseudoSpectralKernel):
     # *** don't remove! needed for diagnostics (but not forward model) ***
     def _advect(self, q, u, v):
         """Given real inputs q, u, v, returns the advective tendency for
-        q in spectal space."""
+        q in spectral space."""
         uq = u*q
         vq = v*q
         # this is a hack, since fft now requires input to have shape (nz,ny,nx)

--- a/pyqg/qg_model.py
+++ b/pyqg/qg_model.py
@@ -82,10 +82,10 @@ class QGModel(model.Model):
             Deformation radius. Units: meters.
         delta : number
             Layer thickness ratio (H1/H2)
-        U1 : number *or* aray-like
-            Upper layer flow. Units: m/s
+        U1 : number *or* array-like
+            Upper layer flow. Units: meters seconds :sup:`-1`
         U2 : number *or* array-like
-            Lower layer flow. Units: m/s
+            Lower layer flow. Units: meters seconds :sup:`-1`
         """
 
         # physical
@@ -197,9 +197,9 @@ class QGModel(model.Model):
         ----------
 
         U1 : number
-            Upper layer flow. Units: m/s
+            Upper layer flow. Units: meters seconds :sup:`-1`
         U2 : number
-            Lower layer flow. Units: m/s
+            Lower layer flow. Units: meters seconds :sup:`-1`
         """
         if len(np.shape(U1)) == 0:
           U1 = U1 * np.ones((self.ny)) 

--- a/pyqg/sqg_model.py
+++ b/pyqg/sqg_model.py
@@ -26,7 +26,7 @@ class SQGModel(model.Model):
         Nb : number
             Buoyancy frequency. Units: seconds :sup:`-1`.
         U : number *or* array-like
-            Background zonal flow. Units: meters.
+            Background zonal flow. Units: meters seconds :sup:`-1`.
         """
 
         # physical


### PR DESCRIPTION
- Layered equations: corrects a sign error in spectral expression for Ekman drag, fixes some typos, and polishes notation
- Two layer, SQG, Equivalent BT: fixes some typos, and polishes notation
-  Fixes developers' affiliations and website urls.
-  Fixes units in comments within models.