### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,6 @@ versionfile_source = pyqg/_version.py
 versionfile_build = pyqg/_version.py
 tag_prefix = v
 parentdir_prefix = pyqg-
+
+[build_ext]
+inplace=1


### PR DESCRIPTION
Added "inplace" flag for build_ext when run `python setup.py install`. Solved the issue "ImportError: No module named kernel".