### PR TITLE
wrap model output with xarray

### DIFF
--- a/ci/environment-py3.7-pyfftw.yml
+++ b/ci/environment-py3.7-pyfftw.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.7
   - numpy
+  - xarray
   - scipy
   - cython
   - pyfftw

--- a/ci/environment-py3.7.yml
+++ b/ci/environment-py3.7.yml
@@ -2,6 +2,7 @@ name: test_env_pyqg
 dependencies:
   - python=3.7
   - numpy
+  - xarray
   - scipy
   - cython
   - pytest

--- a/ci/environment-py3.8-pyfftw.yml
+++ b/ci/environment-py3.8-pyfftw.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.8
   - numpy
+  - xarray
   - scipy
   - cython
   - pyfftw

--- a/ci/environment-py3.8.yml
+++ b/ci/environment-py3.8.yml
@@ -2,6 +2,7 @@ name: test_env_pyqg
 dependencies:
   - python=3.8
   - numpy
+  - xarray
   - scipy
   - cython
   - pytest

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -673,3 +673,8 @@ class Model(PseudoSpectralKernel):
         warnings.warn("Method deprecated. Set model.q directly instead. ",
             DeprecationWarning)
         self.q = q
+
+    def to_dataset(self):
+        '''Convert outputs from model to an xarray dataset'''
+        from .xarray_output import model_to_dataset
+        return model_to_dataset(self)

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -675,6 +675,11 @@ class Model(PseudoSpectralKernel):
         self.q = q
 
     def to_dataset(self):
-        '''Convert outputs from model to an xarray dataset'''
+        """Convert outputs from model to an xarray dataset
+        
+        Returns
+        -------
+        ds : xarray.Dataset
+        """
         from .xarray_output import model_to_dataset
         return model_to_dataset(self)

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -1,0 +1,13 @@
+from __future__ import print_function
+import numpy as np
+import pyqg
+import xarray as xr
+
+def test_xarray():
+    m = pyqg.QGModel(1)
+    ds = m.to_dataset()
+    
+    assert type(ds) == xr.Dataset
+
+if __name__ == "__main__":
+    test_xarray()

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -8,6 +8,9 @@ def test_xarray():
     ds = m.to_dataset()
     
     assert type(ds) == xr.Dataset
-
-if __name__ == "__main__":
-    test_xarray()
+    
+    expected_vars = ['q', 'u', 'v', 'ph', 'Qy']  
+    for v in expected_vars:
+        assert v in ds
+    
+    

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -1,154 +1,149 @@
 import numpy as np
 import xarray as xr
 
+# Define dict for variable dimensions
+spatial_dims = ('time','lev','y','x')
+spectral_dims = ('time','lev','l','k')
+dim_database = {
+    'q': spatial_dims,
+    'u': spatial_dims,
+    'v': spatial_dims,
+    'ufull': spatial_dims,
+    'vfull': spatial_dims, 
+    'qh': spectral_dims,
+    'uh': spectral_dims,
+    'vh': spectral_dims,
+    'ph': spectral_dims, 
+    'Ubg': ('lev'),
+    'Qy': ('lev'),
+}
+
+# dict for variable dimensions
+var_attr_database = {
+    'q': {'long_name': 'potential vorticity in real space', 'units': 'meters squared Kelvin per second per kilogram',},
+    'u': {'long_name': 'zonal velocity anomaly', 'units': 'meters per second',},
+    'v': {'long_name': 'meridional velocity anomaly', 'units': 'meters per second',},
+    'ufull': {'long_name': 'zonal full velocities in real space', 'units': 'meters per second',},
+    'vfull': {'long_name': 'meridional full velocities in real space', 'units': 'meters per second',},
+    'qh': {'long_name': 'potential vorticity in spectral space', 'units': 'meters squared Kelvin per second per kilogram',},
+    'uh': {'long_name': 'zonal velocity anomaly in spectral space', 'units': 'meters per second',},
+    'vh': {'long_name': 'meridional velocity anomaly in spectral space', 'units': 'meters per second',},
+    'ph': {'long_name': 'streamfunction in spectral space', 'units': 'meters squared per second',},
+    'Ubg': {'long_name': 'background zonal velocity', 'units': 'meters per second',},
+    'Qy': {'long_name': 'background potential vorticity gradient', 'units': 'meters squared Kelvin per second per kilogram',} ,
+ 
+}
+
+# dict for coordinate dimensions
+coord_database = {
+    'time': ('time'),
+    'lev': ('lev'),
+    'x': ('x'),
+    'y': ('y'),
+    'l': ('l'),
+    'k': ('k'),
+    'nx': (),
+    'ny': (),
+    'nz': (),
+    'nl': (),
+    'nk': (),
+    'rek': (),
+    'tc': (),
+    'dt': (),
+    'L': (),
+    'W': (),
+    'filterfac': (),
+    'twrite': (),
+    'tmax': (),
+    'tavestart': (),
+    'tsnapstart': (),
+    'taveint': (),
+    'tsnapint': (),
+    'ntd': (),
+    'pmodes': (),
+    'radii': (),
+}
+
+# dict for coordinate attributes 
+coord_attr_database = {
+    'time': {'long_name': 'model time', 'units': 'seconds',},
+    'lev': {'long_name': 'vertical levels',},
+    'x': {'long_name': 'real space grid points in the x direction', 'units': 'grid point',},
+    'y': {'long_name': 'real space grid points in the y direction', 'units': 'grid point',},
+    'l': {'long_name': 'spectal space grid points in the l direction', 'units': 'meridional wavenumber',},
+    'k': {'long_name': 'spectal space grid points in the k direction', 'units': 'zonal wavenumber',},
+    'nx': {'long_name': 'number of real space grid points in x direction',},
+    'ny': {'long_name': 'number of real space grid points in y direction (default: nx)'},
+    'nz': {'long_name': 'number of vertical levels',},
+    'nl': {'long_name': 'number of spectral space grid points in l direction', 'units': 'grid point',},
+    'nk': {'long_name': 'number of spectral space grid points in k direction', 'units': 'grid point',},
+    'rek': {'long_name': 'linear drag in lower layer', 'units': 'per second',},
+    'tc': {'long_name': 'model timestep', 'units': 'seconds',},
+    'dt': {'long_name': 'numerical timestep', 'units': 'seconds',},
+    'L': {'long_name': 'domain length in x direction', 'units': 'meters',},
+    'W': {'long_name': 'domain length in y direction', 'units': 'meters',},
+    'filterfac': {'long_name': 'amplitude of spectral spherical filter', 'units': '',},
+    'twrite': {'long_name': 'interval for cfl writeout', 'units': 'number of timesteps',},
+    'tmax': {'long_name': 'total time of integration', 'units': 'seconds',},
+    'tavestart': {'long_name': 'start time for averaging', 'units': 'seconds',},
+    'tsnapstart': {'long_name': 'start time for snapshot writeout', 'units': 'seconds'},
+    'taveint': {'long_name': 'time interval for accumulation of diagnostic averages', 'units': 'seconds'},
+    'tsnapint': {'long_name': 'time interval for snapshots', 'units': 'seconds',},
+    'ntd': {'long_name': 'number of threads used',},
+    'pmodes': {'long_name': 'vertical pressure modes',},
+    'radii': {'long_name': 'deformation radii', 'units': 'meters',},
+}
+
+# dict for dataset attributes
+ds_attr_database = {
+    'title': 'pyqg: Python Quasigeostrophic Model',
+    'source': ('version: {}'.format(pyqg.__version__)),
+    'references': 'https://pyqg.readthedocs.io/en/latest/index.html',
+}
+
+# Transform certain key coordinates
+transformations = {
+    'time': lambda x: np.array([x.t]),
+    'lev': lambda x: np.arange(1,x.nz+1),
+    'x': lambda x: x.x[0,:],
+    'y': lambda x: x.y[:,0],
+    'l': lambda x: x.ll,
+    'k': lambda x: x.kk,
+}
+
 def model_to_dataset(m):
     '''Convert outputs from model to an xarray dataset'''
 
-   # Define dict for variable dimensions
-    spatial_dims = ('time','z','y','x')
-    spectral_dims = ('time','z','l','k')
-    dim_database = {
-        'q': spatial_dims,
-        'u': spatial_dims,
-        'v': spatial_dims,
-        'ufull': spatial_dims,
-        'vfull': spatial_dims, 
-        'qh': spectral_dims,
-        'uh': spectral_dims,
-        'vh': spectral_dims,
-        'ph': spectral_dims, 
-        'Ubg': ('z'),
-        'Qy': ('z'),
-    }
-
-    # dict for variable dimensions
-    var_attr_database = {
-        'q': {'long_name': 'potential vorticity in real space', 'units': 'm\u00B2 s\u207B\u00B9 K kg\u207B\u00B9',},
-        'u': {'long_name': 'zonal velocity anomaly', 'units': 'm s\u207B\u00B9',},
-        'v': {'long_name': 'meridional velocity anomaly', 'units': 'm s\u207B\u00B9',},
-        'ufull': {'long_name': 'zonal full velocities in real space', 'units': 'm s\u207B\u00B9',},
-        'vfull': {'long_name': 'meridional full velocities in real space', 'units': 'm s\u207B\u00B9',},
-        'qh': {'long_name': 'potential vorticity in spectral space', 'units': 'm\u00B2 s\u207B\u00B9 K kg\u207B\u00B9',},
-        'uh': {'long_name': 'zonal velocity anomaly in spectral space', 'units': 'm s\u207B\u00B9',},
-        'vh': {'long_name': 'meridional velocity anomaly in spectral space', 'units': 'm s\u207B\u00B9',},
-        'ph': {'long_name': 'streamfunction in spectral space', 'units': 'm\u00B2 s\u207B\u00B9',},
-        'Ubg': {'long_name': 'background zonal velocity', 'units': 'm s\u207B\u00B9',},
-        'Qy': {'long_name': 'background potential vorticity gradient', 'units': 'm\u00B2 s\u207B\u00B9 K kg\u207B\u00B9',} ,
-        'kk': {'long_name': 'zonal wavenumbers', 'units': 'm\u207B\u00B9',} ,
-        'll': {'long_name': 'meridional wavenumbers', 'units': 'm\u207B\u00B9',} ,
-    }
-
-    # dict for coordinate dimensions
-    coord_database = {
-        'time': ('time'),
-        'z': ('z'),
-        'x': ('x'),
-        'y': ('y'),
-        'l': ('l'),
-        'k': ('k'),
-        'nx': (),
-        'ny': (),
-        'nz': (),
-        'nl': (),
-        'nk': (),
-        'rek': (),
-        'tc': (),
-        'dt': (),
-        'L': (),
-        'W': (),
-        'filterfac': (),
-        'twrite': (),
-        'tmax': (),
-        'tavestart': (),
-        'tsnapstart': (),
-        'taveint': (),
-        'tsnapint': (),
-        'ntd': (),
-        'pmodes': (),
-        'radii': (),
-    }
-
-    # dict for coordinate attributes 
-    coord_attr_database = {
-        'time': {'long_name': 'model time', 'units': 'seconds',},
-        'z': {'long_name': 'vertical levels', 'units': 'none',},
-        'x': {'long_name': 'real space grid points in the x direction', 'units': 'grid point',},
-        'y': {'long_name': 'real space grid points in the y direction', 'units': 'grid point',},
-        'l': {'long_name': 'spectal space grid points in the l direction', 'units': 'meridional wavenumber',},
-        'k': {'long_name': 'spectal space grid points in the k direction', 'units': 'zonal wavenumber',},
-        'nx': {'long_name': 'number of real space grid points in x direction', 'units': 'none',},
-        'ny': {'long_name': 'number of real space grid points in y direction (default: nx)', 'units': 'none',},
-        'nz': {'long_name': 'number of vertical levels', 'units': 'none',},
-        'nl': {'long_name': 'number of spectral space grid points in l direction', 'units': 'grid point',},
-        'nk': {'long_name': 'number of spectral space grid points in k direction', 'units': 'grid point',},
-        'rek': {'long_name': 'linear drag in lower layer', 'units': 'seconds\u207B\u00B9',},
-        'tc': {'long_name': 'model timestep', 'units': 'seconds',},
-        'dt': {'long_name': 'numerical timestep', 'units': 'seconds',},
-        'L': {'long_name': 'domain length in x direction', 'units': 'meters',},
-        'W': {'long_name': 'domain length in y direction', 'units': 'meters',},
-        'filterfac': {'long_name': 'amplitude of spectral spherical filter', 'units': '',},
-        'twrite': {'long_name': 'interval for cfl writeout', 'units': 'number of timesteps',},
-        'tmax': {'long_name': 'total time of integration', 'units': 'seconds',},
-        'tavestart': {'long_name': 'start time for averaging', 'units': 'seconds',},
-        'tsnapstart': {'long_name': 'start time for snapshot writeout', 'units': 'seconds'},
-        'taveint': {'long_name': 'time interval for accumulation of diagnostic averages', 'units': 'seconds'},
-        'tsnapint': {'long_name': 'time interval for snapshots', 'units': 'seconds',},
-        'ntd': {'long_name': 'number of threads used', 'units': 'none',},
-        'pmodes': {'long_name': 'vertical pressure modes', 'units': 'none',},
-        'radii': {'long_name': 'deformation radii', 'units': 'meters',},
-    }
-
-    # dict for dataset attributes
-    ds_attr_database = {
-        'title': 'pyqg: Python Quasigeostrophic Model',
-        'institution': '',
-        'source': ('version: {}'.format(pyqg.__version__)),
-        'history': '',
-        'references': 'https://pyqg.readthedocs.io/en/latest/index.html',
-        'comment': '', 
-    }
-
-
+    ds = xr.Dataset()
+    
     # Create list of variables
     variables = {}
     for vname in dim_database:
-        data = getattr(m,vname)
-        if 'time' in dim_database[vname]:
-            variables[vname] = (dim_database[vname],data[np.newaxis,...])
-        else:
-            variables[vname] = (dim_database[vname],data)
+        if hasattr(m,vname):
+            data = getattr(m,vname, None)
+            if 'time' in dim_database[vname]:
+                variables[vname] = (dim_database[vname],data[np.newaxis,...])
+                ds = xr.merge([ds, ds.assign(variables)])
+                ds.data_vars[vname].attrs = var_attr_database[vname]
+            else:
+                variables[vname] = (dim_database[vname],data)
+                ds = xr.merge([ds, ds.assign(variables)])
+                ds.data_vars[vname].attrs = var_attr_database[vname]
 
     # Create list of coordinates
     coordinates = {}
-    cname_to_1D = ['time','z','x','y','l','k']
-    coords_1D = [(np.array([m.t])), (np.arange(1,m.nz+1)), (m.x[0,:]), (m.y[:,0]), (m.l[:,0]), (m.k[0,:])] 
     for cname in coord_database:
-        if cname in cname_to_1D:
-            index = cname_to_1D.index(cname)
-            coordinates[cname] = coords_1D[index]
+        if cname in transformations:
+            coordinates[cname] = transformations[cname](m)
+            ds = xr.merge([ds, ds.assign_coords(coordinates)])
+            ds.coords[cname].attrs = coord_attr_database[cname]
         else:
-            try:
-                data = getattr(m, cname, None)
-                if data:
-                    # do something
-                coordinates[cname] = (coord_database[cname],data )
-            except:
-                pass
-
-    # Define dataset
-    ds = xr.Dataset(variables,
-                    coords=coordinates,
-                    attrs=ds_attr_database)
-
-    # Assign attributes to coordinates
-    for caname in coord_attr_database:
-        if caname in ds.coords:
-            ds.coords[caname].attrs = coord_attr_database[caname]
-
-    # Assign attributes to variables
-    for vaname in var_attr_database:
-        if vaname in ds.data_vars:
-            ds.data_vars[vaname].attrs = var_attr_database[vaname]
-
+            if hasattr(m,cname):
+                data = getattr(m, cname)
+                coordinates[cname] = (coord_database[cname],data)
+                ds = xr.merge([ds, ds.assign_coords(coordinates)])
+                ds.coords[cname].attrs = coord_attr_database[cname]
+    
+    ds.attrs = ds_attr_database 
 
     return ds

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -128,7 +128,9 @@ def model_to_dataset(m):
             coordinates[cname] = coords_1D[index]
         else:
             try:
-                data = getattr(m,cname)
+                data = getattr(m, cname, None)
+                if data:
+                    # do something
                 coordinates[cname] = (coord_database[cname],data )
             except:
                 pass

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -1,0 +1,152 @@
+import numpy as np
+import xarray as xr
+
+def model_to_dataset(m):
+    '''Convert outputs from model to an xarray dataset'''
+
+   # Define dict for variable dimensions
+    spatial_dims = ('time','z','y','x')
+    spectral_dims = ('time','z','l','k')
+    dim_database = {
+        'q': spatial_dims,
+        'u': spatial_dims,
+        'v': spatial_dims,
+        'ufull': spatial_dims,
+        'vfull': spatial_dims, 
+        'qh': spectral_dims,
+        'uh': spectral_dims,
+        'vh': spectral_dims,
+        'ph': spectral_dims, 
+        'Ubg': ('z'),
+        'Qy': ('z'),
+    }
+
+    # dict for variable dimensions
+    var_attr_database = {
+        'q': {'long_name': 'potential vorticity in real space', 'units': 'm\u00B2 s\u207B\u00B9 K kg\u207B\u00B9',},
+        'u': {'long_name': 'zonal velocity anomaly', 'units': 'm s\u207B\u00B9',},
+        'v': {'long_name': 'meridional velocity anomaly', 'units': 'm s\u207B\u00B9',},
+        'ufull': {'long_name': 'zonal full velocities in real space', 'units': 'm s\u207B\u00B9',},
+        'vfull': {'long_name': 'meridional full velocities in real space', 'units': 'm s\u207B\u00B9',},
+        'qh': {'long_name': 'potential vorticity in spectral space', 'units': 'm\u00B2 s\u207B\u00B9 K kg\u207B\u00B9',},
+        'uh': {'long_name': 'zonal velocity anomaly in spectral space', 'units': 'm s\u207B\u00B9',},
+        'vh': {'long_name': 'meridional velocity anomaly in spectral space', 'units': 'm s\u207B\u00B9',},
+        'ph': {'long_name': 'streamfunction in spectral space', 'units': 'm\u00B2 s\u207B\u00B9',},
+        'Ubg': {'long_name': 'background zonal velocity', 'units': 'm s\u207B\u00B9',},
+        'Qy': {'long_name': 'background potential vorticity gradient', 'units': 'm\u00B2 s\u207B\u00B9 K kg\u207B\u00B9',} ,
+        'kk': {'long_name': 'zonal wavenumbers', 'units': 'm\u207B\u00B9',} ,
+        'll': {'long_name': 'meridional wavenumbers', 'units': 'm\u207B\u00B9',} ,
+    }
+
+    # dict for coordinate dimensions
+    coord_database = {
+        'time': ('time'),
+        'z': ('z'),
+        'x': ('x'),
+        'y': ('y'),
+        'l': ('l'),
+        'k': ('k'),
+        'nx': (),
+        'ny': (),
+        'nz': (),
+        'nl': (),
+        'nk': (),
+        'rek': (),
+        'tc': (),
+        'dt': (),
+        'L': (),
+        'W': (),
+        'filterfac': (),
+        'twrite': (),
+        'tmax': (),
+        'tavestart': (),
+        'tsnapstart': (),
+        'taveint': (),
+        'tsnapint': (),
+        'ntd': (),
+        'pmodes': (),
+        'radii': (),
+    }
+
+    # dict for coordinate attributes 
+    coord_attr_database = {
+        'time': {'long_name': 'model time', 'units': 'seconds',},
+        'z': {'long_name': 'vertical levels', 'units': 'none',},
+        'x': {'long_name': 'real space grid points in the x direction', 'units': 'grid point',},
+        'y': {'long_name': 'real space grid points in the y direction', 'units': 'grid point',},
+        'l': {'long_name': 'spectal space grid points in the l direction', 'units': 'meridional wavenumber',},
+        'k': {'long_name': 'spectal space grid points in the k direction', 'units': 'zonal wavenumber',},
+        'nx': {'long_name': 'number of real space grid points in x direction', 'units': 'none',},
+        'ny': {'long_name': 'number of real space grid points in y direction (default: nx)', 'units': 'none',},
+        'nz': {'long_name': 'number of vertical levels', 'units': 'none',},
+        'nl': {'long_name': 'number of spectral space grid points in l direction', 'units': 'grid point',},
+        'nk': {'long_name': 'number of spectral space grid points in k direction', 'units': 'grid point',},
+        'rek': {'long_name': 'linear drag in lower layer', 'units': 'seconds\u207B\u00B9',},
+        'tc': {'long_name': 'model timestep', 'units': 'seconds',},
+        'dt': {'long_name': 'numerical timestep', 'units': 'seconds',},
+        'L': {'long_name': 'domain length in x direction', 'units': 'meters',},
+        'W': {'long_name': 'domain length in y direction', 'units': 'meters',},
+        'filterfac': {'long_name': 'amplitude of spectral spherical filter', 'units': '',},
+        'twrite': {'long_name': 'interval for cfl writeout', 'units': 'number of timesteps',},
+        'tmax': {'long_name': 'total time of integration', 'units': 'seconds',},
+        'tavestart': {'long_name': 'start time for averaging', 'units': 'seconds',},
+        'tsnapstart': {'long_name': 'start time for snapshot writeout', 'units': 'seconds'},
+        'taveint': {'long_name': 'time interval for accumulation of diagnostic averages', 'units': 'seconds'},
+        'tsnapint': {'long_name': 'time interval for snapshots', 'units': 'seconds',},
+        'ntd': {'long_name': 'number of threads used', 'units': 'none',},
+        'pmodes': {'long_name': 'vertical pressure modes', 'units': 'none',},
+        'radii': {'long_name': 'deformation radii', 'units': 'meters',},
+    }
+
+    # dict for dataset attributes
+    ds_attr_database = {
+        'title': 'pyqg: Python Quasigeostrophic Model',
+        'institution': '',
+        'source': ('version: {}'.format(pyqg.__version__)),
+        'history': '',
+        'references': 'https://pyqg.readthedocs.io/en/latest/index.html',
+        'comment': '', 
+    }
+
+
+    # Create list of variables
+    variables = {}
+    for vname in dim_database:
+        data = getattr(m,vname)
+        if 'time' in dim_database[vname]:
+            variables[vname] = (dim_database[vname],data[np.newaxis,...])
+        else:
+            variables[vname] = (dim_database[vname],data)
+
+    # Create list of coordinates
+    coordinates = {}
+    cname_to_1D = ['time','z','x','y','l','k']
+    coords_1D = [(np.array([m.t])), (np.arange(1,m.nz+1)), (m.x[0,:]), (m.y[:,0]), (m.l[:,0]), (m.k[0,:])] 
+    for cname in coord_database:
+        if cname in cname_to_1D:
+            index = cname_to_1D.index(cname)
+            coordinates[cname] = coords_1D[index]
+        else:
+            try:
+                data = getattr(m,cname)
+                coordinates[cname] = (coord_database[cname],data )
+            except:
+                pass
+
+    # Define dataset
+    ds = xr.Dataset(variables,
+                    coords=coordinates,
+                    attrs=ds_attr_database)
+
+    # Assign attributes to coordinates
+    for caname in coord_attr_database:
+        if caname in ds.coords:
+            ds.coords[caname].attrs = coord_attr_database[caname]
+
+    # Assign attributes to variables
+    for vaname in var_attr_database:
+        if vaname in ds.data_vars:
+            ds.data_vars[vaname].attrs = var_attr_database[vaname]
+
+
+    return ds

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -126,13 +126,13 @@ def model_to_dataset(m):
     # Create a dictionary of coordinates
     coordinates = {}
     for cname in coord_database:
-        if cname in transformations:
-            coordinates[cname] = (coord_database[cname], transformations[cname](m), coord_attr_database[cname])
-        else:
-            if hasattr(m,cname):
+        if hasattr(m, cname):
+            if cname in transformations:
+                data = transformations[cname](m)
+            else:
                 data = getattr(m, cname)
-                coordinates[cname] = (coord_database[cname], data, coord_attr_database[cname])
-    
+            coordinates[cname] = (coord_database[cname], data, coord_attr_database[cname])
+        
     ds = xr.Dataset(variables, coords=coordinates, attrs=global_attrs)
 
     return ds


### PR DESCRIPTION
This PR address the [issue](https://github.com/pyqg/pyqg/issues/145) of wrapping model variables with xarray. A new function `model_to_dataset` converts the pyqg model output into an xarray dataset. The method `to_dataset` in `model.py` can be called on the model itself to produce the dataset.

**This is a clean branch with only the two files updated added via commits. Thanks @rabernat for pointing this out ;)**