### PR TITLE
Binder build fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,8 +46,8 @@ Links
 .. |landscape| image:: https://landscape.io/github/pyqg/pyqg/master/landscape.svg?style=flat
    :target: https://landscape.io/github/pyqg/pyqg/master
    :alt: Code Health
-.. |binder| image:: http://mybinder.org/badge.svg
-   :target: http://mybinder.org/repo/crocha700/pyqg
+.. |binder| image:: https://mybinder.org/badge_logo.svg
+   :target: https://mybinder.org/v2/gh/pyqg/pyqg/HEAD
 .. |docs| image:: http://readthedocs.org/projects/pyqg/badge/?version=stable
    :target: http://pyqg.readthedocs.org/en/stable/?badge=stable
    :alt: Documentation Status

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ ipython==3.1.0
 numpydoc==0.5
 cython>=0.20
 numpy>=1.8
-pyqg


### PR DESCRIPTION
It looks like the issue reported over in https://github.com/pyqg/pyqg/issues/231 is due `pyqg` being included in `requirements.txt`. Binder uses [`repo2docker`](https://repo2docker.readthedocs.io/en/latest/) to build docker images based on the contents of a git repository. Since `pyqg` has a `setup.py` file, `repo2docker` will always automatically install `pyqg` so it doesn't need to be included in `requirements.txt`. 

That said, I'm not sure if `requirements.txt` is used elsewhere. Doing a quick grep "requirements.txt" didn't turn up anything, but though it'd be good to double check that removing `pyqg` from `requirements.txt` won't unintentionally break something else. 

Closes https://github.com/pyqg/pyqg/issues/231