### PR TITLE
Add diagnostic variables to xarray dataset

### DIFF
--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -9,7 +9,7 @@ def test_xarray():
     
     assert type(ds) == xr.Dataset
     
-    expected_vars = ['q', 'u', 'v', 'ph', 'Qy']  
+    expected_vars = ['q', 'u', 'v', 'ph', 'Qy', 'APEflux', 'EKE']  
     for v in expected_vars:
         assert v in ds
     

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 def test_xarray():
     m = pyqg.QGModel(1)
-    ds = model_to_dataset(m) #m.model_to_dataset()
+    ds = model_to_dataset(m) 
     
     assert type(ds) == xr.Dataset
     

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -4,14 +4,12 @@ import pyqg
 import xarray as xr
 
 def test_xarray():
-    year = 24*60*60*360.
-    m = pyqg.QGModel(tmax=5*year, twrite=10000, tavestart=1*year)
-    m.run()
-    ds = m.to_dataset()
+    m = pyqg.QGModel(1)
+    ds = m.model_to_dataset()
     
     assert type(ds) == xr.Dataset
     
-    expected_vars = ['q', 'u', 'v', 'ph', 'Qy', 'APEflux', 'EKE']  
+    expected_vars = ['q', 'u', 'v', 'ph', 'Qy']  
     for v in expected_vars:
         assert v in ds
     

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -4,7 +4,9 @@ import pyqg
 import xarray as xr
 
 def test_xarray():
-    m = pyqg.QGModel(1)
+    year = 24*60*60*360.
+    m = pyqg.QGModel(tmax=5*year, twrite=10000, tavestart=1*year)
+    m.run()
     ds = m.to_dataset()
     
     assert type(ds) == xr.Dataset

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 def test_xarray():
     m = pyqg.QGModel(1)
-    ds = model_to_dataset(m) 
+    ds = m.to_dataset()
     
     assert type(ds) == xr.Dataset
     

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -5,12 +5,20 @@ import xarray as xr
 
 def test_xarray():
     m = pyqg.QGModel(1)
-    ds = m.to_dataset()
+    ds = model_to_dataset(m) #m.model_to_dataset()
     
     assert type(ds) == xr.Dataset
     
     expected_vars = ['q', 'u', 'v', 'ph', 'Qy']  
     for v in expected_vars:
         assert v in ds
+        
+    expected_attrs = ['L', 'W', 'dt', 'title', 'references']  
+    for a in expected_attrs:
+        assert a in ds.attrs
+        
+    expected_coords = ['time', 'x', 'y', 'l', 'k']  
+    for c in expected_coords:
+        assert c in ds.coords
     
     

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -5,7 +5,7 @@ import xarray as xr
 
 def test_xarray():
     m = pyqg.QGModel(1)
-    ds = m.model_to_dataset()
+    ds = m.to_dataset()
     
     assert type(ds) == xr.Dataset
     

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -115,7 +115,7 @@ transformations = {
 }
 
 def model_to_dataset(m):
-    '''Convert diagnostics from model to an xarray dataset'''
+    '''Convert output from model to an xarray dataset'''
 
     diagnostics = {}
     for dname in diagnostic_database:

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -34,6 +34,28 @@ var_attr_database = {
  
 }
 
+# Define dict for diagnostic dimensions
+diagnostic_database = {
+    'APEflux': ('time','l','k'),
+    'APEgenspec': ('time','l','k'),
+    'EKE': ('time','lev'),
+    'Ensspec': spectral_dims,
+    'KEflux': ('time','l','k'),
+    'KEspec': spectral_dims,
+    'entspec': ('time','l','k'), 
+}
+
+# dict for diagnostics attributes
+diagnostic_attr_database = {
+    'APEflux': {'long_name': 'spectral flux of available potential energy', 'units': '',},
+    'APEgenspec': {'long_name': 'spectrum of APE generation', 'units': '',},
+    'EKE': {'long_name': 'mean eddy kinetic energy', 'units': '',},
+    'Ensspec': {'long_name': 'enstrophy spectrum', 'units': '',},
+    'KEflux': {'long_name': 'spectral flux of kinetic energy', 'units': '',},
+    'KEspec': {'long_name': 'kinetic energy spectrum', 'units': '',},
+    'entspec': {'long_name': 'barotropic enstrophy spectrum', 'units': '',},
+}    
+
 # dict for coordinate dimensions
 coord_database = {
     'time': ('time'),
@@ -123,6 +145,15 @@ def model_to_dataset(m):
             else:
                 variables[vname] = (dim_database[vname], data, var_attr_database[vname])
 
+    diagnostics = {}
+    for dname in diagnostic_database:
+        if m.get_diagnostic(dname).any():
+            data = m.get_diagnostic(dname)
+            if 'time' in diagnostic_database[dname]:
+                diagnostics[dname] = (diagnostic_database[dname], data[np.newaxis,...], diagnostic_attr_database[dname])
+            else:
+                diagnostics[dname] = (diagnostic_database[dname], data, diagnostic_attr_database[dname])
+                
     # Create a dictionary of coordinates
     coordinates = {}
     for cname in coord_database:
@@ -132,7 +163,8 @@ def model_to_dataset(m):
             else:
                 data = getattr(m, cname)
             coordinates[cname] = (coord_database[cname], data, coord_attr_database[cname])
-        
+     
+    variables.update(diagnostics)
     ds = xr.Dataset(variables, coords=coordinates, attrs=global_attrs)
 
     return ds

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -157,7 +157,7 @@ def model_to_dataset(m):
             else:
                 diagnostics[dname] = (diagnostic_database[dname], data, diagnostic_attr_database[dname])   
         except:
-            pass
+            diagnostics[dname] = np.nan
                 
 
     # Create a dictionary of coordinates

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -127,7 +127,7 @@ global_attrs = {
 
 # Transform certain key coordinates
 transformations = {
-    'time': lambda x: np.array([x.t]),
+    'time': lambda x: [x.t],
     'lev': lambda x: np.arange(1,x.nz+1),
     'x': lambda x: x.x[0,:],
     'y': lambda x: x.y[:,0],
@@ -163,12 +163,12 @@ def model_to_dataset(m):
     # Create a dictionary of coordinates
     coordinates = {}
     for cname in coord_database:
-        if hasattr(m, cname):
-            if cname in transformations:
-                data = transformations[cname](m)
-            else:
+        if cname in transformations:
+            data = transformations[cname](m)
+        else:
+            if hasattr(m, cname):
                 data = getattr(m, cname)
-            coordinates[cname] = (coord_database[cname], data, coord_attr_database[cname])
+        coordinates[cname] = (coord_database[cname], data, coord_attr_database[cname])
      
     variables.update(diagnostics)
         

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -115,7 +115,7 @@ transformations = {
 }
 
 def model_to_dataset(m):
-    '''Convert output from model to an xarray dataset'''
+    '''Convert outputs from model to an xarray dataset'''
 
     diagnostics = {}
     for dname in diagnostic_database:

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -147,12 +147,14 @@ def model_to_dataset(m):
 
     diagnostics = {}
     for dname in diagnostic_database:
-        if m.get_diagnostic(dname).any():
+        try: 
             data = m.get_diagnostic(dname)
             if 'time' in diagnostic_database[dname]:
                 diagnostics[dname] = (diagnostic_database[dname], data[np.newaxis,...], diagnostic_attr_database[dname])
             else:
-                diagnostics[dname] = (diagnostic_database[dname], data, diagnostic_attr_database[dname])
+                diagnostics[dname] = (diagnostic_database[dname], data, diagnostic_attr_database[dname])   
+        except:
+            pass
                 
     # Create a dictionary of coordinates
     coordinates = {}


### PR DESCRIPTION
This PR adds available diagnostic variables to the output of the xarray dataset when calling `m.to_dataset()`. 

The following diagnostics are added if available:

- APEflux
- APEgen
- APEgenspec
- EKE
- EKEdiss
- Ensspec
- KEflux
- KEspec
- entspec
