### PR TITLE
Support xarray concatenation of simulation snapshots across time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ target/
 
 # notebooks
 */.ipynb_checkpoints/*
+
+# .swp files from text editors
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,6 @@ target/
 # notebooks
 */.ipynb_checkpoints/*
 
-# .swp files from text editors
+# .swp/.swo files from text editors
 *.swp
+*.swo

--- a/pyqg/model.py
+++ b/pyqg/model.py
@@ -591,14 +591,14 @@ class Model(PseudoSpectralKernel):
             description='total energy dissipation by bottom drag',
             function= (lambda self: self.Hi[-1]/self.H*self.rek*(self.v[-1]**2 + self.u[-1]**2).mean()),
             units='',
-            dims=('time')
+            dims=('time',)
         )
 
         self.add_diagnostic('EKE',
             description='mean eddy kinetic energy',
             function= (lambda self: 0.5*(self.v**2 + self.u**2).mean(axis=-1).mean(axis=-1)),
             units='',
-            dims=('lev')
+            dims=('lev',)
         )
 
     def _calc_derived_fields(self):

--- a/pyqg/qg_model.py
+++ b/pyqg/qg_model.py
@@ -287,7 +287,7 @@ class QGModel(model.Model):
                             np.conj(self.ph[0,:,1:-2] - self.ph[1,:,1:-2])).sum()) /
                             (self.M**2) ),
             units='',
-            dims=('time')
+            dims=('time',)
        )
         ### These generic diagnostics are now calculated in model.py ###
         # self.add_diagnostic('KE1spec',

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -142,6 +142,10 @@ def test_xarray(all_models):
             for v in list(ds.keys()): 
                 assert v in expected_vars + expected_diags
 
+            for v in expected_diags:
+                if v in ds:
+                    assert 'time' in ds[v].coords
+
             for a in expected_attrs:
                 assert f"pyqg:{a}" in ds.attrs
 

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -155,7 +155,6 @@ def test_xarray(all_models):
             for c in expected_coords:
                 assert c in ds.coords
 
-    if len(datasets):
-        concatenated = xr.concat(datasets, dim='time')
+    concatenated = xr.concat(datasets, dim='time')
 
-        assert np.allclose(concatenated.coords['time'], timevals)
+    assert np.allclose(concatenated.coords['time'], timevals)

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -69,7 +69,7 @@ expected_coords = [
 
 def QG():
     '''Initialize Two-layer Model'''
-    return pyqg.QGModel(tmax=year/2, twrite=10000, tavestart=year/3)
+    return pyqg.QGModel(tmax=year/2, twrite=1000, tavestart=year/3)
 
 def Layered():
     '''Initialize Layered quasigeostrophic model'''
@@ -94,24 +94,21 @@ def Layered():
     f0  = 0.0001236812857687059 # coriolis param [s^-1]
     beta = 1.2130692965249345e-11 # planetary vorticity gradient [m^-1 s^-1]
 
-    Ti = Ld/(abs(U1))  # estimate of most unstable e-folding time scale [s]
-    dt = Ti/200.       # time-step [s]
-    tmax = 300*Ti      # simulation time [s]
-
-    return pyqg.LayeredModel(nx=Nx, nz=3, U = [U1,U2,U3],V = [0.,0.,0.],L=L,f=f0,beta=beta,
-                             H = [H1,H2,H3], rho=[rho1,rho2,rho3],rek=rek,
-                            dt=dt,tmax=tmax, twrite=5000, tavestart=Ti*10)
+    return pyqg.LayeredModel(nx=Nx, nz=3, U=[U1,U2,U3], V=[0.,0.,0.], L=L, f=f0, beta=beta,
+                             H=[H1,H2,H3], rho=[rho1,rho2,rho3], rek=rek,
+                             tmax=year/2, twrite=1000, tavestart=year/3)
 
 def BT():
     '''Initialize Barotropic model'''
     return pyqg.BTModel(L=2.*np.pi, nx=256, beta=0., H=1., rek=0., 
-                     rd=None, tmax=40, dt=0.001, taveint=1, ntd=4)
+                        rd=None, tmax=year/2, twrite=1000, tavestart=year/3,
+                        dt=year/8, taveint=1, ntd=4)
     
 def SQG():
     '''Initialize Surface Quasi-Geostrophic Model'''
-    return pyqg.SQGModel(L=2.*np.pi, nx=512, tmax = 26.005, beta = 0., 
-                           Nb = 1., H = 1., rek = 0., rd = None, dt = 0.005,
-                           taveint=1, twrite=400, ntd=4)
+    return pyqg.SQGModel(L=2.*np.pi, nx=512, tmax=year/2, beta=0.,
+                         Nb=1., H=1., rek=0., rd=None, dt=year/8,
+                         taveint=1, twrite=1000, ntd=4, tavestart=year/3)
     
 @pytest.fixture(params=[QG, Layered, BT, SQG])
 def all_models(request):

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -158,6 +158,7 @@ def test_xarray(all_models):
             for c in expected_coords:
                 assert c in ds.coords
 
-    concatenated = xr.concat(datasets, dim='time')
+    if len(datasets):
+        concatenated = xr.concat(datasets, dim='time')
 
-    assert np.allclose(concatenated.coords['time'], timevals)
+        assert np.allclose(concatenated.coords['time'], timevals)

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -122,9 +122,15 @@ def test_xarray(all_models):
     '''Run with snapshots and test contents of xarray.dataset'''
     m=all_models
     tsnapint=year/4
+    datasets = []
+    timevals = []
+
     for snapshot in m.run_with_snapshots(tsnapstart=m.t, tsnapint=tsnapint):
         ds = m.to_dataset()
         assert type(ds) == xr.Dataset
+
+        datasets.append(ds)
+        timevals.append(m.t)
 
         if snapshot < tsnapint:
 
@@ -151,3 +157,7 @@ def test_xarray(all_models):
 
             for c in expected_coords:
                 assert c in ds.coords
+
+    concatenated = xr.concat(datasets, dim='time')
+
+    assert np.allclose(concatenated.coords['time'], timevals)

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -132,7 +132,13 @@ def model_to_dataset(m):
             if isinstance(data, np.float64):
                 data = np.array([m.get_diagnostic(diag_name)])
             attrs = {'long_name': m.diagnostics[diag_name]['description'], 'units': m.diagnostics[diag_name]['units'],}
-            diagnostics[diag_name] = (dims, data, attrs)
+            # Ensure time is added to diagnostic data so simulation timesteps
+            # can be stacked
+            if 'time' not in dims:
+                aug_dims = tuple(['time'] + list(dims))
+                diagnostics[diag_name] = (aug_dims, data[np.newaxis,...], attrs)
+            else:
+                diagnostics[diag_name] = (dims, data, attrs)
         except DiagnosticNotFilledError:
             pass
     

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -145,7 +145,6 @@ def model_to_dataset(m):
     variables.update(diagnostics)
     
     ds = xr.Dataset(variables, coords=coordinates, attrs=global_attrs)
-    ds.assign_coords(time=np.array([m.t]))
     ds.attrs['title'] = 'pyqg: Python Quasigeostrophic Model'
     ds.attrs['reference'] = 'https://pyqg.readthedocs.io/en/latest/index.html'
     

--- a/pyqg/xarray_output.py
+++ b/pyqg/xarray_output.py
@@ -145,6 +145,7 @@ def model_to_dataset(m):
     variables.update(diagnostics)
     
     ds = xr.Dataset(variables, coords=coordinates, attrs=global_attrs)
+    ds.assign_coords(time=np.array([m.t]))
     ds.attrs['title'] = 'pyqg: Python Quasigeostrophic Model'
     ds.attrs['reference'] = 'https://pyqg.readthedocs.io/en/latest/index.html'
     


### PR DESCRIPTION
This pull request slightly tweaks the handling of time to support the following use-case:

```python
pyqg_outputs_over_time = xr.concat(
    [snapshot.to_dataset() for snapshot in pyqg.QGModel().run_with_snapshots()],
    dim="time"
)
```

The main way it does this is by adding a time dimension to diagnostics (even though they are time-averaged, but averages can still evolve) and updating the time coordinate of the resulting dataset to the current time of the model.