### PR TITLE
SQG inversion relation 

### DIFF
--- a/docs/equations/notation_sqg_model.rst
+++ b/docs/equations/notation_sqg_model.rst
@@ -68,7 +68,7 @@ Taking the Fourier transform in the x and y directions with :math:`\kappa^2 = k^
 .. math::
 
 
-    \frac{f_0^2}{N^2}\frac{\partial }{\partial z}\left(\frac{\partial \hat \psi}{\partial z}\right) = \kappa^2 \nabla^2\psi\,,
+    \frac{f_0^2}{N^2}\frac{\partial }{\partial z}\left(\frac{\partial \hat \psi}{\partial z}\right) = \kappa^2 \psi\,,
     
 which has solution
 
@@ -78,5 +78,11 @@ which has solution
    \hat \psi = Ae^{\frac{\kappa N}{f_0}z} + Be^{-\frac{\kappa N}{f_0}z},.
    
 
-Our decay at negative infinity immediately tells us that :math:`B = 0`. Differentiating with respect to :math:`z` and evaluating at the surface tells us :math:`A = f_0 \hat b / \kappa N` so that we have the result. 
+Our decay at negative infinity immediately tells us that :math:`B = 0`. Differentiating with respect to :math:`z` and evaluating at the surface tells us :math:`A = f_0 \hat b / \kappa N` so that we have:
 
+.. math::
+
+
+   \hat \psi = \frac{f_0 \hat b}{\kappa N }e^{\frac{\kappa N}{f_0}z},.
+
+Evaluating at :math:`z = 0` gives the inversion relation given above. 

--- a/docs/equations/notation_sqg_model.rst
+++ b/docs/equations/notation_sqg_model.rst
@@ -60,7 +60,7 @@ model.
 .. math::
 
 
-    \frac{\partial }{\partial z}\left(\frac{f_0^2}{N^2}\frac{\partial \psi}{\partial z}\right) + \nabla^2\psi = 0\,
+    \frac{\partial }{\partial z}\left(\frac{f_0^2}{N^2}\frac{\partial \psi(x,y,z)}{\partial z}\right) + \nabla^2\psi(x,y,z) = 0\,
 
 
 Taking the Fourier transform in the x and y directions with :math:`\kappa^2 = k^2 + l^2`  we get
@@ -83,6 +83,6 @@ Our decay at negative infinity immediately tells us that :math:`B = 0`. Differen
 .. math::
 
 
-   \hat \psi = \frac{f_0 \hat b}{\kappa N }e^{\frac{\kappa N}{f_0}z},.
+   \hat \psi(k,l,z) = \frac{f_0}{N}\frac{1}{\kappa} \hat b(k,l,z) e^{\frac{\kappa N}{f_0}z},.
 
 Evaluating at :math:`z = 0` gives the inversion relation given above. 

--- a/docs/equations/notation_sqg_model.rst
+++ b/docs/equations/notation_sqg_model.rst
@@ -40,7 +40,7 @@ and
 
    \psi = 0,  \qquad \text{at} \qquad z \rightarrow -\infty\,.
 
-The solutions to the elliptic problem above, in horizontal Fourier
+The solutions to the elliptic problem above*, in horizontal Fourier
 space, gives the inversion relationship between surface buoyancy and
 surface streamfunction
 
@@ -51,3 +51,27 @@ surface streamfunction
 
 The SQG evolution equation is marched forward similarly to the two-layer
 model.
+
+
+* Since understanding this step is key to making your own modifications to the model, in more detail:
+
+.. math::
+
+
+    \frac{\partial }{\partial t}\left(\frac{f_0^2}{N^2}\frac{\partial \psi}{\partial z}\right) + \nabla^2\psi = 0\,
+    
+Taking the Fourier transform with kappa equal to k^2 + l^2 we get
+.. math::
+
+
+    \frac{f_0^2}{N^2}\frac{\partial }{\partial t}\left(\frac{\partial \hat \psi}{\partial z}\right) = \kappa^2 \nabla^2\psi\,,
+    
+which has solution
+
+.. math::
+
+
+   \hat \psi = Ae^{\frac{\kappa N}{f_0}z} + Be^{-\frac{\kappa N}{f_0}z},.
+   
+Our decay at negative infinity immediately tells us that B = 0. Differentiating with respect to z and evaluating at the surface tells us $A = f_0 \hat b / \kappa N$ so that we have the result. 
+ 

--- a/docs/equations/notation_sqg_model.rst
+++ b/docs/equations/notation_sqg_model.rst
@@ -68,7 +68,7 @@ Taking the Fourier transform in the x and y directions with :math:`\kappa^2 = k^
 .. math::
 
 
-    \frac{f_0^2}{N^2}\frac{\partial }{\partial z}\left(\frac{\partial \hat \psi}{\partial z}\right) = \kappa^2 \psi\,,
+    \frac{f_0^2}{N^2}\frac{\partial }{\partial z}\left(\frac{\partial \hat \psi}{\partial z}\right) = \kappa^2 \hat\psi\,,
     
 which has solution
 

--- a/docs/equations/notation_sqg_model.rst
+++ b/docs/equations/notation_sqg_model.rst
@@ -53,7 +53,7 @@ The SQG evolution equation is marched forward similarly to the two-layer
 model.
 
 
-* Since understanding this step is key to making your own modifications to the model, in more detail:
+\* Since understanding this step is key to making your own modifications to the model, in more detail:
 
 .. math::
 

--- a/docs/equations/notation_sqg_model.rst
+++ b/docs/equations/notation_sqg_model.rst
@@ -60,7 +60,7 @@ model.
 .. math::
 
 
-    \frac{\partial }{\partial t}\left(\frac{f_0^2}{N^2}\frac{\partial \psi}{\partial z}\right) + \nabla^2\psi = 0\,
+    \frac{\partial }{\partial z}\left(\frac{f_0^2}{N^2}\frac{\partial \psi}{\partial z}\right) + \nabla^2\psi = 0\,
 
 
 Taking the Fourier transform in the x and y directions with :math:`\kappa^2 = k^2 + l^2`  we get
@@ -68,7 +68,7 @@ Taking the Fourier transform in the x and y directions with :math:`\kappa^2 = k^
 .. math::
 
 
-    \frac{f_0^2}{N^2}\frac{\partial }{\partial t}\left(\frac{\partial \hat \psi}{\partial z}\right) = \kappa^2 \nabla^2\psi\,,
+    \frac{f_0^2}{N^2}\frac{\partial }{\partial z}\left(\frac{\partial \hat \psi}{\partial z}\right) = \kappa^2 \nabla^2\psi\,,
     
 which has solution
 

--- a/docs/equations/notation_sqg_model.rst
+++ b/docs/equations/notation_sqg_model.rst
@@ -53,14 +53,18 @@ The SQG evolution equation is marched forward similarly to the two-layer
 model.
 
 
+=======
+
 \* Since understanding this step is key to making your own modifications to the model, in more detail:
 
 .. math::
 
 
     \frac{\partial }{\partial t}\left(\frac{f_0^2}{N^2}\frac{\partial \psi}{\partial z}\right) + \nabla^2\psi = 0\,
-    
-Taking the Fourier transform with kappa equal to k^2 + l^2 we get
+
+
+Taking the Fourier transform in the x and y directions with :math:`\kappa = k^2 + l^2`  we get
+
 .. math::
 
 
@@ -73,5 +77,6 @@ which has solution
 
    \hat \psi = Ae^{\frac{\kappa N}{f_0}z} + Be^{-\frac{\kappa N}{f_0}z},.
    
-Our decay at negative infinity immediately tells us that B = 0. Differentiating with respect to z and evaluating at the surface tells us $A = f_0 \hat b / \kappa N$ so that we have the result. 
- 
+
+Our decay at negative infinity immediately tells us that :math:`B = 0`. Differentiating with respect to :math:`z` and evaluating at the surface tells us :math:`A = f_0 \hat b / \kappa N` so that we have the result. 
+

--- a/docs/equations/notation_sqg_model.rst
+++ b/docs/equations/notation_sqg_model.rst
@@ -63,7 +63,7 @@ model.
     \frac{\partial }{\partial t}\left(\frac{f_0^2}{N^2}\frac{\partial \psi}{\partial z}\right) + \nabla^2\psi = 0\,
 
 
-Taking the Fourier transform in the x and y directions with :math:`\kappa = k^2 + l^2`  we get
+Taking the Fourier transform in the x and y directions with :math:`\kappa^2 = k^2 + l^2`  we get
 
 .. math::
 

--- a/docs/examples/sqg.ipynb
+++ b/docs/examples/sqg.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "Using the fact that the Potential Vorticity is exactly zero in the interior of the domain and that the domain is semi-infinite, yields that the inversion in Fourier space is,\n",
     "$$\n",
-    "\\hat b = K \\hat \\psi.\n",
+    "\\hat b = \\frac{\\kappa N}{f_0} \\hat \\psi.\n",
     "$$"
    ]
   },
@@ -101,7 +101,7 @@
     "# create the model object\n",
     "year = 1.\n",
     "m = sqg_model.SQGModel(L=2.*pi,nx=512, tmax = 26.005,\n",
-    "        beta = 0., Nb = 1., H = 1., rek = 0., rd = None, dt = 0.005,\n",
+    "        beta = 0., Nb = 1., H = 1., f_0 = 1, dt = 0.005,\n",
     "                     taveint=1, twrite=400, ntd=4)\n",
     "# in this example we used ntd=4, four threads\n",
     "# if your machine has more (or fewer) cores available, you could try changing it"
@@ -449,7 +449,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -463,7 +463,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,

--- a/docs/examples/sqg.rst
+++ b/docs/examples/sqg.rst
@@ -70,7 +70,7 @@ pedagogical reasons.
     # create the model object
     year = 1.
     m = sqg_model.SQGModel(L=2.*pi,nx=512, tmax = 26.005,
-            beta = 0., Nb = 1., H = 1., rek = 0., rd = None, dt = 0.005,
+            beta = 0., Nb = 1., H = 1., f_0 = 0., dt = 0.005,
                          taveint=1, twrite=400, ntd=4)
     # in this example we used ntd=4, four threads
     # if your machine has more (or fewer) cores available, you could try changing it

--- a/docs/examples/sqg.rst
+++ b/docs/examples/sqg.rst
@@ -57,7 +57,7 @@ the inversion in Fourier space is,
 .. math::
 
 
-   \hat b = K \hat \psi.
+   \hat b = \frac{\kappa N}{f_0} \hat \psi.
 
 Held et al. studied several different cases, the first of which was the
 nonlinear evolution of an elliptical vortex. There are several other

--- a/examples/SQG_ellipticalvortex.py
+++ b/examples/SQG_ellipticalvortex.py
@@ -6,7 +6,7 @@ from pyqg import sqg_model
 # the model object
 year = 1.
 m = sqg_model.SQGModel(L=2.*pi,nx=512, tmax = 40.005,
-        beta = 0., Nb = 1., H = 1., rek = 0., rd = None, dt = 0.005,
+        beta = 0., Nb = 1., H = 1., f_0 = 1, dt = 0.005,
                      taveint=1, ntd=4)
 
 # run the model and plot some figs

--- a/pyqg/sqg_model.py
+++ b/pyqg/sqg_model.py
@@ -10,7 +10,7 @@ class SQGModel(model.Model):
         self,
         beta=0.,                    # gradient of coriolis parameter
         Nb = 1.,                    # Buoyancy frequency
-        rd=0.,                      # deformation radius
+        f_0 = 1.,                   # coriolis parameter
         H = 1.,                     # depth of layer
         U=0.,                       # max vel. of base-state
         **kwargs
@@ -31,8 +31,7 @@ class SQGModel(model.Model):
         # physical
         self.beta = beta
         self.Nb = Nb
-        #self.rek = rek
-        self.rd = rd
+        self.f_0 = f_0
         self.H = H
         self.Hi = np.array(H)[np.newaxis,...]
         self.U = U
@@ -63,8 +62,8 @@ class SQGModel(model.Model):
 
     def _initialize_inversion_matrix(self):
         """ the inversion """
-        # The sqg model is diagonal. The inversion is simply qh = -kappa**2 ph
-        self.a = np.asarray(self.Nb*np.sqrt(self.wv2i))[np.newaxis, np.newaxis, :, :]
+        # The sqg inversion is ph = f / (kappa * N) qh (see documentation) 
+        self.a = np.asarray(self.f_0/self.Nb*np.sqrt(self.wv2i))[np.newaxis, np.newaxis, :, :]
 
     def _initialize_forcing(self):
         pass

--- a/pyqg/tests/test_reference_solns.py
+++ b/pyqg/tests/test_reference_solns.py
@@ -149,7 +149,7 @@ class ReferenceSolutionsTester(unittest.TestCase):
         qi = m.ifft(qih)
         m.set_q(qi)
 
-        rtol = 1.e-5
+        rtol = 1.e-4
         atol = 1.e-14
 
         np.testing.assert_allclose(m.q, qi, atol)

--- a/pyqg/tests/test_reference_solns.py
+++ b/pyqg/tests/test_reference_solns.py
@@ -136,7 +136,7 @@ class ReferenceSolutionsTester(unittest.TestCase):
         """ Tests against some statistics of a reference sqg solution """
 
         m = pyqg.SQGModel(L=2.*np.pi,nx=64, tmax = 5.,
-                beta = 0., H = 1., f_0 = 1., dt = 0.0025,
+                beta = 0., H = 1., dt = 0.0025,
                 twrite=1000)
 
         p = np.exp(-(2.*(m.x-1.75*np.pi/2))**2.-(2.*(m.y-np.pi))**2) +\

--- a/pyqg/tests/test_reference_solns.py
+++ b/pyqg/tests/test_reference_solns.py
@@ -136,7 +136,7 @@ class ReferenceSolutionsTester(unittest.TestCase):
         """ Tests against some statistics of a reference sqg solution """
 
         m = pyqg.SQGModel(L=2.*np.pi,nx=64, tmax = 5.,
-                beta = 0., H = 1., rek = 0., dt = 0.0025,
+                beta = 0., H = 1., f_0 = 1., dt = 0.0025,
                 twrite=1000)
 
         p = np.exp(-(2.*(m.x-1.75*np.pi/2))**2.-(2.*(m.y-np.pi))**2) +\

--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -106,7 +106,7 @@ def BT():
 def SQG():
     '''Initialize Surface Quasi-Geostrophic Model'''
     return pyqg.SQGModel(L=2.*np.pi, nx=512, tmax=year/2, beta=0.,
-                         Nb=1., H=1., rek=0., rd=None, dt=year/8,
+                         Nb=1., H=1., f_0 = 1., dt=year/8,
                          taveint=1, twrite=1000, ntd=4, tavestart=year/3)
     
 @pytest.fixture(params=[QG, Layered, BT, SQG])


### PR DESCRIPTION
fix #178 

I changed the inversion relation in the SQG model, to see why it must be this (the same as what is in the documentation but not the ipython example or comments) see my addition to the docs. 
I also removed rd and rek from the arguments (they don't do anything and so are quite misleading for anyone trying to quickly get started) and added the Coriolis parameter. I could have used rd instead but this is not how the equations are usually presented and figuring out what H should be would be tricky. 
The examples for SQG have been changed to reflect my changes.