### PR TITLE
Add real streamfunction and real/spectral dqdts to xarray

### DIFF
--- a/pyqg/tests/test_xarray_output.py
+++ b/pyqg/tests/test_xarray_output.py
@@ -11,12 +11,15 @@ expected_vars = [
     'v', 
     'ufull', 
     'vfull', 
+    'p',
+    'dqdt',
     'qh', 
     'uh', 
     'vh', 
     'ph', 
     'Ubg', 
     'Qy',
+    'dqhdt',
 ]
 
 expected_diags = [


### PR DESCRIPTION
I need to save the real-space values of the streamfunction and the PV tendencies locally, so I had written a wrapper around `pyqg.Model#to_dataset` to include them. However, I'm making a pull request to add them directly within the model, since they might be generally useful to include (at least for the streamfunction, the only variable that `to_dataset` includes in spectral but not real space).