### PR TITLE
Add workflow to publish to testpypi

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,32 @@
+name: Publish to TestPyPI
+
+on:
+  # Publish to TestPyPI when we push to master
+  push:
+    branches: [ master ]
+
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install setuptools build wheel twine
+    - name: Build
+      run: |
+        python -m build --sdist --outdir dist/
+    - name: Publish
+      run: |
+        python -m twine upload dist/*
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: $${ secrets.TEST_PYPI_API_TOKEN }}
+        TWINE_REPOSITORY: testpypi


### PR DESCRIPTION
This PR, based on [this guide](https://dev.to/arnu515/create-a-pypi-pip-package-test-it-and-publish-it-using-github-actions-part-2-1o83), creates a job which will automatically update testpypi whenever we push to master.

If it works, I'll plan to create a follow-up PR with a second action that triggers a publish to pypi proper whenever we create a tagged github release. This will greatly simplify the publish process, allowing us to do everything from within github and ensuring that creating the release, adding the tag, and publishing to pypi all happen in a single atomic step.