### PR TITLE
Update calc_ispec to resolve issues and (sort of) preserve units

### DIFF
--- a/pyqg/diagnostic_tools.py
+++ b/pyqg/diagnostic_tools.py
@@ -115,14 +115,9 @@ def calc_ispec(model, _var_dens, averaging = True, truncate=True, nd_wavenumber=
     # convert left border of the bin to center
     kr = kr + dkr/2
 
-    # convert to non-dimensional wavenumber 
-    # preserving integral over spectrum
+    # normalize / potentially convert to non-dimensional wavenumber 
+    phr = phr * kmin
     if nd_wavenumber:
         kr = kr / kmin
-        phr = phr * kmin
-    else:
-        # Otherwise, multiply by dkr to approximately preserve the original
-        # units of the spectrum.
-        phr = phr * dkr
 
     return kr, phr

--- a/pyqg/diagnostic_tools.py
+++ b/pyqg/diagnostic_tools.py
@@ -93,7 +93,7 @@ def calc_ispec(model, _var_dens, averaging = True, truncate=True, nd_wavenumber=
     else:
         kmax = np.sqrt(ll_max**2 + kk_max**2)
     
-    kmin = np.minimum(model.dk, model.dl)
+    kmin = 0
 
     dkr = np.sqrt(model.dk**2 + model.dl**2) * nfactor
 
@@ -106,13 +106,13 @@ def calc_ispec(model, _var_dens, averaging = True, truncate=True, nd_wavenumber=
         if i == kr.size-1:
             fkr = (model.wv>=kr[i]) & (model.wv<=kr[i]+dkr)
         else:
-            fkr = (model.wv>=kr[i]) & (model.wv<kr[i]+dkr)
+            fkr = (model.wv>=kr[i]) & (model.wv<kr[i+1])
         if averaging:
             phr[i] = var_dens[fkr].mean() * (kr[i]+dkr/2) * pi / (model.dk * model.dl)
         else:
             phr[i] = var_dens[fkr].sum() / dkr
 
-        #phr[i] *= 2 # include full circle
+        phr[i] *= 2 # include full circle
     
     # convert left border of the bin to center
     kr = kr + dkr/2

--- a/pyqg/diagnostic_tools.py
+++ b/pyqg/diagnostic_tools.py
@@ -77,9 +77,6 @@ def calc_ispec(model, _var_dens, averaging = True, truncate=True, nd_wavenumber=
         isotropic wavenumber
     phr : array
         isotropic spectrum
-
-    Normalization:
-    signal2d.var()/2 = phr.sum() * (kr[1] - kr[0])
     """
 
     # account for complex conjugate

--- a/pyqg/diagnostic_tools.py
+++ b/pyqg/diagnostic_tools.py
@@ -112,7 +112,7 @@ def calc_ispec(model, _var_dens, averaging = True, truncate=True, nd_wavenumber=
         else:
             phr[i] = var_dens[fkr].sum() / dkr
 
-        phr[i] *= 2 # include full circle
+        #phr[i] *= 2 # include full circle
     
     # convert left border of the bin to center
     kr = kr + dkr/2

--- a/pyqg/tests/test_diagnostic_tools.py
+++ b/pyqg/tests/test_diagnostic_tools.py
@@ -46,17 +46,14 @@ def test_calc_ispec_units():
         if m1.diagnostics[diagnostic]['dims'] == ('l','k'):
             spec1 = m1.diagnostics[diagnostic]['function'](m1)
             spec2 = m2.diagnostics[diagnostic]['function'](m2)
-            spec1x = spec1.sum(axis=0)
-            spec1y = spec1.sum(axis=1)
-            spec2x = spec2.sum(axis=0)
-            spec2y = spec2.sum(axis=1)
-            _, spec1r = calc_ispec(m1, spec1)
-            _, spec2r = calc_ispec(m2, spec2)
+            k1r, spec1r = calc_ispec(m1, spec1)
+            k2r, spec2r = calc_ispec(m2, spec2)
 
             scales = [
-                np.abs(spec).mean()
-                for spec in [spec1x, spec1y, spec1r,
-                             spec2x, spec2y, spec2r]
+                np.abs(spec1).sum(),
+                np.abs(spec2).sum(),
+                np.trapz(np.abs(spec1r), k1r),
+                np.trapz(np.abs(spec2r), k2r)
             ]
 
             if max(scales) == 0:
@@ -64,8 +61,8 @@ def test_calc_ispec_units():
 
             scale_ratio = max(scales) / min(scales)
 
-            assert scale_ratio < 4, \
-                f"calc_ispec should preserve units of {diagnostic}"
-            assert scale_ratio > 0.25, \
-                f"calc_ispec should preserve units of {diagnostic}"
+            assert scale_ratio < 10, \
+                f"calc_ispec should have correct units for {diagnostic}"
+            assert scale_ratio > 0.1, \
+                f"calc_ispec should have correct units for {diagnostic}"
 

--- a/pyqg/tests/test_diagnostic_tools.py
+++ b/pyqg/tests/test_diagnostic_tools.py
@@ -1,9 +1,11 @@
 import numpy as np
 import pyqg
 import pytest
+import os
+import pickle
 from pyqg.diagnostic_tools import calc_ispec
 
-def test_calc_ispec():
+def test_calc_ispec_peak():
     # Create a radial sine wave spiraling out from the center of the model's
     # spatial field (with a given frequency)
     m = pyqg.QGModel()
@@ -21,3 +23,49 @@ def test_calc_ispec():
     spectrum_peak_idx = np.argmax(iso_spectrum)
     sinewave_freq_idx = np.argmin(np.abs(iso_wavenumbers - frequency))
     assert spectrum_peak_idx == sinewave_freq_idx
+
+def test_calc_ispec_units():
+    fixtures_path = f"{os.path.dirname(os.path.realpath(__file__))}/fixtures"
+
+    with open(f"{fixtures_path}/LayeredModel_params.pkl", 'rb') as f:
+        # Common set of parameters for each model
+        params = pickle.load(f)
+
+    m1 = pyqg.LayeredModel(nx=96, **params)
+    m2 = pyqg.LayeredModel(nx=64, **params)
+    m1.q = np.load(f"{fixtures_path}/LayeredModel_nx96_q.npy")
+    m2.q = np.load(f"{fixtures_path}/LayeredModel_nx64_q.npy")
+    for m in [m1, m2]:
+        m._invert()
+        m._calc_derived_fields()
+
+    for diagnostic in m1.diagnostics.keys():
+        if 'Dissspec' in diagnostic:
+            continue
+
+        if m1.diagnostics[diagnostic]['dims'] == ('l','k'):
+            spec1 = m1.diagnostics[diagnostic]['function'](m1)
+            spec2 = m2.diagnostics[diagnostic]['function'](m2)
+            spec1x = spec1.sum(axis=0)
+            spec1y = spec1.sum(axis=1)
+            spec2x = spec2.sum(axis=0)
+            spec2y = spec2.sum(axis=1)
+            _, spec1r = calc_ispec(m1, spec1)
+            _, spec2r = calc_ispec(m2, spec2)
+
+            scales = [
+                np.abs(spec).max()
+                for spec in [spec1x, spec1y, spec1r,
+                             spec2x, spec2y, spec2r]
+            ]
+
+            if max(scales) == 0:
+                continue
+
+            scale_ratio = max(scales) / min(scales)
+
+            assert scale_ratio < 5, \
+                f"calc_ispec should preserve units of {diagnostic}"
+            assert scale_ratio > 0.2, \
+                f"calc_ispec should preserve units of {diagnostic}"
+

--- a/pyqg/tests/test_diagnostic_tools.py
+++ b/pyqg/tests/test_diagnostic_tools.py
@@ -24,7 +24,7 @@ def test_calc_ispec_peak():
     sinewave_freq_idx = np.argmin(np.abs(iso_wavenumbers - frequency))
     assert spectrum_peak_idx == sinewave_freq_idx
 
-def test_calc_ispec_units(rtol=1e-2):
+def test_calc_ispec_units(rtol=1e-5):
     fixtures_path = f"{os.path.dirname(os.path.realpath(__file__))}/fixtures"
 
     with open(f"{fixtures_path}/LayeredModel_params.pkl", 'rb') as f:
@@ -46,7 +46,7 @@ def test_calc_ispec_units(rtol=1e-2):
                 k, ispec = calc_ispec(m, power, averaging=False)
                 dk = k[1]-k[0]
                 np.testing.assert_allclose(
-                    signal2d.var()/2,
+                    signal2d.var(),
                     ispec.sum()*dk,
                     rtol,
                     err_msg=f"ispec should have correct integral for {a}{z+1}"
@@ -85,7 +85,7 @@ def test_calc_ispec_sum():
 
         # Check that Parseval's theorem is exactly satisfied without averaging or truncation
         kr, Ehr = calc_ispec(m, Eh_model, truncate=False, averaging=False)
-        E_total_radial = np.cumsum(Ehr * (kr[1]-kr[0]))[-1]
+        E_total_radial = Ehr.sum() * (kr[1]-kr[0])
         np.testing.assert_allclose(E_total_radial, Eh_numpy.sum())
 
 if __name__ == "__main__":

--- a/pyqg/tests/test_diagnostic_tools.py
+++ b/pyqg/tests/test_diagnostic_tools.py
@@ -64,8 +64,8 @@ def test_calc_ispec_units():
 
             scale_ratio = max(scales) / min(scales)
 
-            assert scale_ratio < 5, \
+            assert scale_ratio < 4, \
                 f"calc_ispec should preserve units of {diagnostic}"
-            assert scale_ratio > 0.2, \
+            assert scale_ratio > 0.25, \
                 f"calc_ispec should preserve units of {diagnostic}"
 

--- a/pyqg/tests/test_diagnostic_tools.py
+++ b/pyqg/tests/test_diagnostic_tools.py
@@ -40,15 +40,16 @@ def test_calc_ispec_units(rtol=1e-2):
         m._calc_derived_fields()
         for a in ['q','p']:
             for z in [0,1]:
-                ah = a+'h'
                 signal2d = getattr(m, a)[z]
-                power = np.abs(getattr(m, ah)[z])**2/m.M**2
+                spectral = getattr(m, a+'h')[z]
+                power = np.abs(spectral)**2/m.M**2
                 k, ispec = calc_ispec(m, power, averaging=False)
+                dk = k[1]-k[0]
                 np.testing.assert_allclose(
                     signal2d.var()/2,
-                    ispec.sum()*(k[1]-k[0])/2,
+                    ispec.sum()*dk,
                     rtol,
-                    err_msg=f"ispec should have correct units for {a} at z={z}"
+                    err_msg=f"ispec should have correct integral for {a}{z+1}"
                 )
 
 if __name__ == "__main__":

--- a/pyqg/tests/test_diagnostic_tools.py
+++ b/pyqg/tests/test_diagnostic_tools.py
@@ -40,7 +40,7 @@ def test_calc_ispec_units():
         m._calc_derived_fields()
 
     for diagnostic in m1.diagnostics.keys():
-        if 'Dissspec' in diagnostic:
+        if diagnostic == 'Dissspec':
             continue
 
         if m1.diagnostics[diagnostic]['dims'] == ('l','k'):
@@ -54,7 +54,7 @@ def test_calc_ispec_units():
             _, spec2r = calc_ispec(m2, spec2)
 
             scales = [
-                np.abs(spec).max()
+                np.abs(spec).mean()
                 for spec in [spec1x, spec1y, spec1r,
                              spec2x, spec2y, spec2r]
             ]


### PR DESCRIPTION
Hopefully resolves https://github.com/pyqg/pyqg/issues/275 (using @Pperezhogin's implementation times a normalization factor to preserve units), but it would be great to get some detailed feedback on this.

Effect of these changes:
- Fixes the minimum radial wavenumber
- Fixes a potentially problematic (though probably fine) double-counting issue
- Allows for more options re: averaging
- Changes the normalization of the isotropic spectrum, so the values aren't many orders of magnitude different than the those of the zonal or meridional spectrum (but I'm not 100% sure if multiplying by `dkr` or `kmin` is more correct)

Illustration:
![image](https://user-images.githubusercontent.com/1022564/167154677-8c3b892e-8f33-4f6d-9da4-6857a8f08b8a.png)