### PR TITLE
WIP: extracting kernel to a separate object using delegation

### DIFF
--- a/pyqg/bt_model.py
+++ b/pyqg/bt_model.py
@@ -43,15 +43,13 @@ class BTModel(model.Model):
         self.Hi = np.array(H)[np.newaxis,...]
         self.U = U
 
-        self.nz = 1
-
         # deformation wavenumber
         if rd:
             self.kd2 = rd**-2
         else:
             self.kd2 = 0.
 
-        super().__init__(**kwargs)
+        super().__init__(nz=1, **kwargs)
 
         # initial conditions: (PV anomalies)
         self.set_q(1e-3*np.random.rand(1,self.ny,self.nx))

--- a/pyqg/kernel.pyx
+++ b/pyqg/kernel.pyx
@@ -117,8 +117,14 @@ cdef class PseudoSpectralKernel:
     cdef object _dummy_fft
     cdef object _dummy_ifft
 
-    def __init__(self, int nz, int ny, int nx, int fftw_num_threads=1,
-            int has_q_param=0, int has_uv_param=0):
+    cdef public object q_parameterization
+    cdef public object uv_parameterization
+
+    def __init__(self, int nz, int ny, int nx,
+            object q_parameterization=None,
+            object uv_parameterization=None,
+            int fftw_num_threads=1,
+        ):
         self.nz = nz
         self.ny = ny
         self.nx = nx
@@ -160,8 +166,11 @@ cdef class PseudoSpectralKernel:
         vqh = self._empty_com()
         self.vqh = vqh
 
+        self.q_parameterization = q_parameterization
+        self.uv_parameterization = uv_parameterization
+
         # variables for subgrid parameterizations
-        if has_uv_param:
+        if uv_parameterization is not None:
             du = self._empty_real()
             dv = self._empty_real()
             duh = self._empty_com()
@@ -171,7 +180,7 @@ cdef class PseudoSpectralKernel:
             self.duh = duh
             self.dvh = dvh
 
-        if has_q_param:
+        if q_parameterization is not None:
             dq = self._empty_real()
             dqh = self._empty_com()
             self.dq = dq
@@ -220,14 +229,14 @@ cdef class PseudoSpectralKernel:
                              direction='FFTW_BACKWARD', axes=(-2,-1))
             self.ifft_vh_to_v = pyfftw.FFTW(vh, v, threads=fftw_num_threads,
                              direction='FFTW_BACKWARD', axes=(-2,-1))
-            if has_uv_param:
+            if uv_parameterization is not None:
                 self.fft_du_to_duh = pyfftw.FFTW(du, duh, threads=fftw_num_threads,
                                                  direction='FFTW_FORWARD',
                                                  axes=(-2, -1))
                 self.fft_dv_to_dvh = pyfftw.FFTW(dv, dvh, threads=fftw_num_threads,
                                                  direction='FFTW_FORWARD',
                                                  axes=(-2, -1))
-            if has_q_param:
+            if q_parameterization is not None:
                 self.fft_dq_to_dqh = pyfftw.FFTW(dq, dqh, threads=fftw_num_threads,
                                                  direction='FFTW_FORWARD',
                                                  axes=(-2, -1))

--- a/pyqg/layered_model.py
+++ b/pyqg/layered_model.py
@@ -118,8 +118,8 @@ class LayeredModel(qg_diagnostics.QGDiagnostics):
         if H is None: H = [500] + [1750 for _ in range(nz-1)]
         if rho is None: rho = np.arange(nz) * 0.3 + 1025
 
-        self.Ubg = np.array(U)
-        self.Vbg = np.array(V)
+        self._U = U
+        self._V = V
         self.Hi = np.array(H)
         self.rhoi = np.array(rho)
 
@@ -178,6 +178,9 @@ class LayeredModel(qg_diagnostics.QGDiagnostics):
 
     def _initialize_background(self):
         """Set up background state (zonal flow and PV gradients)."""
+
+        self.Ubg = np.array(self._U)
+        self.Vbg = np.array(self._V)
 
         self.H = self.Hi.sum()
 

--- a/pyqg/qg_model.py
+++ b/pyqg/qg_model.py
@@ -86,19 +86,19 @@ class QGModel(qg_diagnostics.QGDiagnostics):
         U2 : number
             Lower layer flow. Units: meters seconds :sup:`-1`
         """
+        if 'nz' in kwargs:
+            del kwargs['nz']
+
+        self.delta = delta
+        self.Hi = np.array([ H1, H1/delta])
 
         # physical
         self.beta = beta
         #self.rek = rek
         self.rd = rd
-        self.delta = delta
-        self.Hi = np.array([ H1, H1/delta])
         self.U1 = U1
         self.U2 = U2
         #self.filterfac = filterfac
-
-        if 'nz' in kwargs:
-            del kwargs['nz']
 
         super().__init__(nz=2, **kwargs)
 

--- a/pyqg/sqg_model.py
+++ b/pyqg/sqg_model.py
@@ -37,9 +37,7 @@ class SQGModel(model.Model):
         self.U = U
         #self.filterfac = filterfac
 
-        self.nz = 1
-
-        super().__init__(**kwargs)
+        super().__init__(nz=1, **kwargs)
 
         # initial conditions: (PV anomalies)
         self.set_q(1e-3*np.random.rand(1,self.ny,self.nx))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cython>=0.20
 numpy>=1.20
 pyfftw
 importlib_metadata
+delegate-property


### PR DESCRIPTION
This pull requests makes `pyqg.Model` a top-level class, invoking `pyqg.PseudoSpectralKernel` by dependency injection rather than inheritance.

This change will allow us to pass in alternative kernels (e.g. jax or numpy without Cython), addressing https://github.com/pyqg/pyqg/issues/240.

Note that as currently implemented, I'm using the [delegate-property](https://github.com/dscottboggs/python-delegate) package, which adds a dependency. Because it's is a [fairly short library](https://github.com/dscottboggs/python-delegate/blob/master/delegate/__init__.py), I could copy it over if we think it might cause problems, or at least lock the version in `requirements.txt`.