### PR TITLE
Fixing U1 and U2 notation in two-layer documentation

### DIFF
--- a/docs/equations/notation_twolayer_model.rst
+++ b/docs/equations/notation_twolayer_model.rst
@@ -6,18 +6,22 @@ The two-layer quasigeostrophic evolution equations are (1)
 .. math::
 
 
-   \partial_t\,{q_1} + \mathsf{J}\left(\psi_1\,, q_1\right) + \beta\, {\psi_1}_x = \text{ssd} \,,
+   \partial_t\,{q_1} + \mathsf{J}\left(\psi_1\,, q_1\right) + \beta\, {\psi_1}_x 
+   + {Q_1}_y{\psi_1}_x + U_1{q_1}_x = \text{ssd},
+
 
 and (2)
 
 .. math::
 
 
-   \partial_t\,{q_2} + \mathsf{J}\left(\psi_2\,, q_2\right)+ \beta\, {\psi_2}_x = -r_{ek}\nabla^2 \psi_2 + \text{ssd}\,,
+   \partial_t\,{q_2} + \mathsf{J}\left(\psi_2\,, q_2\right)+ \beta\, {\psi_2}_x 
+   + {Q_2}_y{\psi_2}_x + U_2 {q_2}_x = -r_{ek}\nabla^2 \psi_2 + \text{ssd},
 
 where the horizontal Jacobian is
-:math:`\mathsf{J}\left(A\,, B\right) = A_x B_y - A_y B_x`. Also in (1)
-and (2) ssd denotes small-scale dissipation (in turbulence regimes, ssd
+:math:`\mathsf{J}\left(A\,, B\right) = A_x B_y - A_y B_x`, and :math:`Q_1` 
+and :math:`Q_2` are background PV. Also in (1)
+and (2), ssd denotes small-scale dissipation (in turbulence regimes, ssd
 absorbs enstrophy that cascades towards small scales). The linear bottom
 drag in (2) dissipates large-scale energy.
 
@@ -61,14 +65,16 @@ base-state shear :math:`U_1-U_2`. In this case the evolution equations
 .. math::
 
 
-   \partial_t\,{q_1} + \mathsf{J}\left(\psi_1\,, q_1\right) + \beta_1\, {\psi_1}_x = \text{ssd} \,,
+   \partial_t\,{q_1} + \mathsf{J}\left(\psi_1\,, q_1\right) + \beta_1\, {\psi_1}_x
+   + U_1\, {q_1}_x = \text{ssd} \,,
 
 and (6)
 
 .. math::
 
 
-   \partial_t\,{q_2} + \mathsf{J}\left(\psi_2\,, q_2\right)+ \beta_2\, {\psi_2}_x = -r_{ek}\nabla^2 \psi_2 + \text{ssd}\,,
+   \partial_t\,{q_2} + \mathsf{J}\left(\psi_2\,, q_2\right)+ \beta_2\, {\psi_2}_x
+   + U_2\, {q_2}_x = -r_{ek}\nabla^2 \psi_2 + \text{ssd}\,,
 
 where the mean potential vorticity gradients are (9,10)
 
@@ -87,16 +93,18 @@ model. Fourier transforming the evolution equations (5) and (6) gives
 .. math::
 
 
-   \partial_t\,{\widehat{q}_1} = - \widehat{\mathsf{J}}\left(\psi_1\,, q_1\right) - \text{i}\,k\, \beta_1\, {\widehat{\psi}_1} + \widehat{\text{ssd}} \,,
+   \partial_t\,{\hat{q}_1} = - \hat{\mathsf{J}}\left(\psi_1\,, q_1\right) - \text{i}\,k\, \beta_1\, {\hat{\psi}_1}
+   - \text{i}\, k\, U_1\, \hat{q}_1 + \widehat{\text{ssd}} \,,
 
 and
 
 .. math::
 
 
-   \partial_t\,{\widehat{q}_2} = - \widehat{\mathsf{J}}\left(\psi_2\,, q_2\right)-  \text{i}\,k\, \beta_2\, {\widehat{\psi}_2}  + r_{ek}\,\kappa^2\,\, \widehat{\psi}_2 + \widehat{\text{ssd}}\,,
+   \partial_t\,{\hat{q}_2} = - \hat{\mathsf{J}}\left(\psi_2\,, q_2\right)-  \text{i}\,k\, \beta_2\, {\hat{\psi}_2}
+   - \text{i}\, k\, U_2\, \hat{q}_2 + r_{ek}\,\kappa^2\,\, \hat{\psi}_2 + \widehat{\text{ssd}}\,,
 
-where, in the pseudo-spectral spirit, :math:`\widehat{\mathsf{J}}` means the
+where, in the pseudo-spectral spirit, :math:`\hat{\mathsf{J}}` means the
 Fourier transform of the Jacobian i.e., we compute the products in
 physical space, and then transform to Fourier space.
 
@@ -110,12 +118,12 @@ In Fourier space the "inversion relation" (3)-(4) is
    \:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:F_2 \qquad - (\kappa^2 + F_2)\;
    \end{bmatrix}}_{\equiv \,\mathsf{M_2}}
    \begin{bmatrix}
-   \widehat{\psi}_1\\
-   \widehat{\psi}_2\\
+   \hat{\psi}_1\\
+   \hat{\psi}_2\\
    \end{bmatrix}
    =\begin{bmatrix}
-   \widehat{q}_1\\
-   \widehat{q}_2\\
+   \hat{q}_1\\
+   \hat{q}_2\\
    \end{bmatrix}
    \,,
 
@@ -125,8 +133,8 @@ or equivalently
 
 
    \begin{bmatrix}
-   \widehat{\psi}_1\\
-   \widehat{\psi}_2\\
+   \hat{\psi}_1\\
+   \hat{\psi}_2\\
    \end{bmatrix}
    =\underbrace{\frac{1}{\text{det}\,\mathrm{M_2}}
    \begin{bmatrix}
@@ -134,8 +142,8 @@ or equivalently
    \:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:\:-F_2 \qquad - (\kappa^2 + F_1)\;
    \end{bmatrix}}_{=\,\mathsf{M_2}^{-1}}
    \begin{bmatrix}
-   \widehat{q}_1\\
-   \widehat{q}_2\\
+   \hat{q}_1\\
+   \hat{q}_2\\
    \end{bmatrix}
    \,,\qquad
 
@@ -154,28 +162,28 @@ We use a third-order Adams-Bashford scheme
 .. math::
 
 
-   {\widehat{q}_i}^{n+1} = E_f\times\left[{\widehat{q}_i}^{n} + \frac{\Delta t}{12}\left(23\, \widehat{Q}_i^{n} -  16\widehat{Q}_i^{n-1} + 5 \widehat{Q}_i^{n-2}\right)\right]\,,
+   {\hat{q}_i}^{n+1} = E_f\times\left[{\hat{q}_i}^{n} + \frac{\Delta t}{12}\left(23\, \hat{Q}_i^{n} -  16\hat{Q}_i^{n-1} + 5 \hat{Q}_i^{n-2}\right)\right]\,,
 
 where
 
 .. math::
 
 
-   \widehat{Q}_i^n \equiv - \widehat{\mathsf{J}}\left(\psi_i^n\,, q_i^n\right) - \text{i}\,k\, \beta_i\, {\widehat{\psi}_i^n}, \qquad i = 1,2\,.
+   \hat{Q}_i^n \equiv - \hat{\mathsf{J}}\left(\psi_i^n\,, q_i^n\right) - \text{i}\,k\, \beta_i\, {\hat{\psi}_i^n}, \qquad i = 1,2\,.
 
 The AB3 is initialized with a first-order AB (or forward Euler)
 
 .. math::
 
 
-   {\widehat{q}_i}^{1} = E_f\times\left[{\widehat{q}_i}^{0} + \Delta t \widehat{Q}_i^{0}\right]\,,
+   {\hat{q}_i}^{1} = E_f\times\left[{\hat{q}_i}^{0} + \Delta t \hat{Q}_i^{0}\right]\,,
 
 The second step uses a second-order AB scheme
 
 .. math::
 
 
-   {\widehat{q}_i}^{2} = E_f\times\left[{\widehat{q}_i}^{1} + \frac{\Delta t}{2}\left(3\, \widehat{Q}_i^{1} -  \widehat{Q}_i^0\right)\right]\,.
+   {\hat{q}_i}^{2} = E_f\times\left[{\hat{q}_i}^{1} + \frac{\Delta t}{2}\left(3\, \hat{Q}_i^{1} -  \hat{Q}_i^0\right)\right]\,.
 
 The small-scale dissipation is achieve by a highly-selective exponential
 filter
@@ -205,7 +213,7 @@ whithin machine double precision:
 
    \frac{\log 10^{-15}}{(0.35\, \pi)^4} \approx -23.5\,.
 
-For experiments with :math:`|\widehat{q_i}|\ll\mathcal{O}(1)` one can use a
+For experiments with :math:`|\hat{q}_i|\ll\mathcal{O}(1)` one can use a
 smaller constant.
 
 Diagnostics


### PR DESCRIPTION
Currently, the documentation for the two-layer QG model (`QGModel`) is missing advection of q by the background flow U_1 and U_2. This PR adds background flow to the documentation. 