### PR TITLE
Resolve most test warnings

### DIFF
--- a/pyqg/bt_model.py
+++ b/pyqg/bt_model.py
@@ -54,7 +54,7 @@ class BTModel(model.Model):
         super().__init__(**kwargs)
 
         # initial conditions: (PV anomalies)
-        self.set_q(1e-3*np.random.rand(1,self.ny,self.nx))
+        self.q = 1e-3*np.random.rand(1,self.ny,self.nx)
 
     def _initialize_background(self):
         """Set up background state (zonal flow and PV gradients)."""

--- a/pyqg/layered_model.py
+++ b/pyqg/layered_model.py
@@ -127,7 +127,7 @@ class LayeredModel(qg_diagnostics.QGDiagnostics):
 
         self.vertical_modes()
 
-        self.set_q(1e-7*np.vstack([
+        self.q = (1e-7*np.vstack([
             np.random.randn(self.nx,self.ny)[np.newaxis,]
             for _ in range(nz)]))
 

--- a/pyqg/qg_model.py
+++ b/pyqg/qg_model.py
@@ -180,7 +180,7 @@ class QGModel(qg_diagnostics.QGDiagnostics):
         q1 : array-like
             Lower layer PV anomaly in spatial coordinates.
         """
-        self.set_q(np.vstack([q1[np.newaxis,:,:], q2[np.newaxis,:,:]]))
+        self.q = np.vstack([q1[np.newaxis,:,:], q2[np.newaxis,:,:]])
         #self.q[0] = q1
         #self.q[1] = q2
 

--- a/pyqg/sqg_model.py
+++ b/pyqg/sqg_model.py
@@ -42,7 +42,7 @@ class SQGModel(model.Model):
         super().__init__(**kwargs)
 
         # initial conditions: (PV anomalies)
-        self.set_q(1e-3*np.random.rand(1,self.ny,self.nx))
+        self.q = 1e-3*np.random.rand(1,self.ny,self.nx)
 
     ### PRIVATE METHODS - not meant to be called by user ###
 

--- a/pyqg/tests/test_diagnostic_tools.py
+++ b/pyqg/tests/test_diagnostic_tools.py
@@ -43,7 +43,7 @@ def test_calc_ispec_peak():
     radial_sine = np.sin(radius * frequency)
 
     # Take its FFT
-    radial_sine_fft = m.fft(np.array([radial_sine, radial_sine]))[0]
+    radial_sine_fft = np.abs(m.fft(np.array([radial_sine, radial_sine]))[0])**2
 
     # Compute an isotropic spectrum
     iso_wavenumbers, iso_spectrum = calc_ispec(m, radial_sine_fft)

--- a/pyqg/tests/test_model.py
+++ b/pyqg/tests/test_model.py
@@ -315,7 +315,7 @@ class PyqgModelTester(unittest.TestCase):
         """Make sure timstepping works properly."""
 
         # set initial conditions to zero
-        self.m.set_q(np.zeros_like(self.m.q))
+        self.m.q = np.zeros_like(self.m.q)
 
         # create a random tendency
         dqhdt = np.random.rand(*self.m.dqhdt.shape) + 1j*np.random.rand(*self.m.dqhdt.shape)

--- a/pyqg/tests/test_reference_solns.py
+++ b/pyqg/tests/test_reference_solns.py
@@ -110,7 +110,7 @@ class ReferenceSolutionsTester(unittest.TestCase):
         pih = ( ph/np.sqrt(KEaux) )
         qih = -m.wv2*pih
         qi = m.ifft(qih)
-        m.set_q(qi)
+        m.q = qi
 
         rtol = 1.e-5
         atol = 1.e-14
@@ -150,7 +150,7 @@ class ReferenceSolutionsTester(unittest.TestCase):
         ph = ( ph/np.sqrt(KEaux) )
         qih = m.wv*ph
         qi = m.ifft(qih)
-        m.set_q(qi)
+        m.q = qi
 
         rtol = 1.e-4
         atol = 1.e-14

--- a/pyqg/tests/test_vertical_modes.py
+++ b/pyqg/tests/test_vertical_modes.py
@@ -18,7 +18,7 @@ class VerticalModesTester(unittest.TestCase):
 
         self.atol=1.e-16
 
-        self.m.set_q(np.random.randn(self.m.nz,self.m.ny,self.m.nx))
+        self.m.q = np.random.randn(self.m.nz,self.m.ny,self.m.nx)
 
         self.m.vertical_modes()
 


### PR DESCRIPTION
This should update all the internal uses of `set_q()` in favor of setting the attribute directly.

This also fixes one warning about truncating complex values to real in one of the `calc_ispec` tests.
