### PR TITLE
Cython updates

### DIFF
--- a/pyqg/kernel.pyx
+++ b/pyqg/kernel.pyx
@@ -123,7 +123,7 @@ cdef class PseudoSpectralKernel:
         self.ny = ny
         self.nx = nx
         self.nl = ny
-        self.nk = nx/2 + 1
+        self.nk = nx//2 + 1
         self.a = np.zeros((self.nz, self.nz, self.nl, self.nk), DTYPE_com)
         self.kk = np.zeros((self.nk), DTYPE_real)
         self._ik = np.zeros((self.nk), DTYPE_com)

--- a/pyqg/kernel.pyx
+++ b/pyqg/kernel.pyx
@@ -6,9 +6,8 @@
 import numpy as np
 import numpy.fft as npfft
 import warnings
-import cython
 cimport numpy as np
-from cython.parallel import prange, threadid
+from cython.parallel import prange
 
 try:
     import pyfftw

--- a/pyqg/kernel.pyx
+++ b/pyqg/kernel.pyx
@@ -279,10 +279,7 @@ cdef class PseudoSpectralKernel:
         """Allocate a space-grid-sized variable for use with fftw transformations."""
         shape = (self.nz, self.ny, self.nx)
         if pyfftw is not None:
-            out = pyfftw.n_byte_align_empty(shape,
-                                 pyfftw.simd_alignment, dtype=DTYPE_real)
-            out.flat[:] = 0.
-            return out
+            return pyfftw.zeros_aligned(shape, dtype=DTYPE_real)
         else:
             return np.zeros(shape, dtype=DTYPE_real)
 
@@ -290,10 +287,7 @@ cdef class PseudoSpectralKernel:
         """Allocate a Fourier-grid-sized variable for use with fftw transformations."""
         shape = (self.nz, self.nl, self.nk)
         if pyfftw is not None:
-            out = pyfftw.n_byte_align_empty(shape,
-                                 pyfftw.simd_alignment, dtype=DTYPE_com)
-            out.flat[:] = 0.+0.j
-            return out
+            return pyfftw.zeros_aligned(shape, dtype=DTYPE_com)
         else:
             return np.zeros(shape, dtype=DTYPE_com)
 

--- a/pyqg/kernel.pyx
+++ b/pyqg/kernel.pyx
@@ -1,8 +1,8 @@
-#cython: profile=True
 #cython: boundscheck=False
 #cython: wraparound=False
 #cython: nonecheck=False
-#from __future__ import division
+#cython: language_level=3
+#distutils: define_macros=NPY_NO_DEPRECATED_API=NPY_1_15_API_VERSION
 import numpy as np
 import warnings
 import cython

--- a/pyqg/kernel.pyx
+++ b/pyqg/kernel.pyx
@@ -101,8 +101,6 @@ cdef class PseudoSpectralKernel:
 
     # threading
     cdef int num_threads
-    # number of elements per work group in the y / l direction
-    cdef int chunksize
 
     # pyfftw objects (callable)
     cdef object fft_q_to_qh
@@ -203,8 +201,6 @@ cdef class PseudoSpectralKernel:
 
         # for threading
         self.num_threads = fftw_num_threads
-        self.chunksize = self.nl/self.num_threads
-
         IF PYQG_USE_PYFFTW:
             # set up FFT plans
             # Note that the Backwards Real transform for the case
@@ -322,7 +318,6 @@ cdef class PseudoSpectralKernel:
         # set ph to zero
         for k in range(self.nz):
             for j in prange(self.nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.nk):
                     self.ph[k,j,i] = (0. + 0.*1j)
@@ -331,7 +326,6 @@ cdef class PseudoSpectralKernel:
         for k2 in range(self.nz):
             for k1 in range(self.nz):
                 for j in prange(self.nl, nogil=True, schedule='static',
-                          chunksize=self.chunksize,
                           num_threads=self.num_threads):
                     for i in range(self.nk):
                         self.ph[k2,j,i] = ( self.ph[k2,j,i] +
@@ -340,7 +334,6 @@ cdef class PseudoSpectralKernel:
         # calculate spectral velocities
         for k in range(self.nz):
             for j in prange(self.nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.nk):
                     self.uh[k,j,i] = -self._il[j] * self.ph[k,j,i]
@@ -371,7 +364,6 @@ cdef class PseudoSpectralKernel:
         # multiply to get advective flux in space
         for k in range(self.nz):
             for j in prange(self.ny, nogil=True, schedule='static',
-                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.nx):
                     self.uq[k,j,i] = (self.u[k,j,i]+self.Ubg[k]) * self.q[k,j,i]
@@ -385,7 +377,6 @@ cdef class PseudoSpectralKernel:
         # spectral divergence
         for k in range(self.nz):
             for j in prange(self.nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.nk):
                     # overwrite the tendency, since the forcing gets called after
@@ -411,7 +402,6 @@ cdef class PseudoSpectralKernel:
         self.fft_dv_to_dvh()
         for k in range(self.nz):
             for j in prange(self.nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.nk):
                     self.dqhdt[k,j,i] = (
@@ -435,7 +425,6 @@ cdef class PseudoSpectralKernel:
         self.fft_dq_to_dqh()
         for k in range(self.nz):
             for j in prange(self.nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.nk):
                     self.dqhdt[k,j,i] = (self.dqhdt[k,j,i] + self.dqh[k,j,i])
@@ -450,7 +439,6 @@ cdef class PseudoSpectralKernel:
         cdef Py_ssize_t j, i
         if self.rek:
             for j in prange(self.nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.nk):
                     self.dqhdt[k,j,i] = (
@@ -496,7 +484,6 @@ cdef class PseudoSpectralKernel:
 
         for k in range(self.nz):
             for j in prange(self.nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.nk):
                     qh_new[k,j,i] = self.filtr[j,i] * (
@@ -516,7 +503,6 @@ cdef class PseudoSpectralKernel:
 
         for k in range(self.nz):
             for j in prange(self.nl, nogil=True, schedule='static',
-                      chunksize=self.chunksize,
                       num_threads=self.num_threads):
                 for i in range(self.nk):
                     self.qh[k,j,i] = qh_new[k,j,i]

--- a/setup.py
+++ b/setup.py
@@ -64,16 +64,6 @@ install_requires = [
     'pyfftw'
 ]
 
-# This hack tells cython whether pyfftw is present
-use_pyfftw_file = 'pyqg/.compile_time_use_pyfftw.pxi'
-with open(use_pyfftw_file, 'wb') as f:
-    try:
-        import pyfftw
-        f.write(b'DEF PYQG_USE_PYFFTW = 1')
-    except ImportError:
-        f.write(b'DEF PYQG_USE_PYFFTW = 0')
-        warnings.warn('Could not import pyfftw. Model may be slower.')
-
 # check for openmp following
 # http://stackoverflow.com/questions/16549893/programatically-testing-for-openmp-support-from-a-python-setup-script
 # see http://openmp.org/wp/openmp-compilers/


### PR DESCRIPTION
This updates some of the flags in the Cython kernel

Cython seems to be in the process of releasing a version 3.0 which deprecates a few things. This should mostly follow their [migration steps](https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html)

This also removes the manual chunksize calculation since the default for the static schedule should divide the workload up evenly.

## PyFFTW conditional compilation

One of the things it that seems to be under consideration for deprecation is conditional compilation (with `IF`) used to select pyfftw/np (cython/cython#4310).

The logic for selecting between the two is only run in the `PseudoSpectralKernel.__init__` so we can instead do the selection at runtime.

The existing implementation calls pyFFTW through the Python interface and this doesn't change that.

In the case of the NumPy FFT fallback there might be some slight overhead because of calling through a bound method object, but I would expect that to be small, and users almost certainly use pyFFTW since it is installed by default.