### PR TITLE
3/2 and 2/3 dealiasing as alternatives to exponential filter

### DIFF
--- a/pyqg/kernel.pyx
+++ b/pyqg/kernel.pyx
@@ -592,6 +592,9 @@ cdef class PseudoSpectralKernel:
     property dqhdt:
         def __get__(self):
             return np.asarray(self.dqhdt)
+        def __set__(self, np.ndarray[DTYPE_com_t, ndim=3] b):
+            cdef  DTYPE_com_t [:, :, :] b_view = b
+            self.dqhdt[:] = b_view
     property dqhdt_p:
         def __get__(self):
             return np.asarray(self.dqhdt_p)


### PR DESCRIPTION
It may be interesting to run pyqg model without any small-scale dissipation mechanism. Mostly, for the purpose of subgrid modeling where any small-scale dissipation mechanism would imply that it is a part of a subgrid model. 

Running pyqg as is without an exponential filter is numerically unstable (and unjustified). The presented here 2/3 and 3/2 dealiasing methods are proposed instead of the exponential filter. These dealiasing rules remove aliasing errors and most importantly allow to build pyqg model which is conservative in PV, total energy and potential enstrophy (**for anomalies**). This dynamical core can be used for training subgrid models with Machine Learning which are consistent in offline and online analysis (not included into PR).

An example of 3/2-dealiasing method + ML subgrid models is shown below. Compared to the exponential filter, there is no discrepancy in energy transfer near the grid scale. 

[3-2-dealiasing-48.pdf](https://github.com/pyqg/pyqg/files/12098579/3-2-dealiasing-48.pdf)

