### PR TITLE
Fix inversion matrix for the BT model

### DIFF
--- a/pyqg/bt_model.py
+++ b/pyqg/bt_model.py
@@ -72,8 +72,11 @@ class BTModel(model.Model):
 
     def _initialize_inversion_matrix(self):
         """ the inversion """
-        # The bt model is diagonal. The inversion is simply qh = -kappa**2 ph
-        self.a = -(self.wv2i+self.kd2)[np.newaxis, np.newaxis, :, :]
+        # The bt model is diagonal. The inversion is simply qh = -(kappa**2 + kd**2)**-1 ph
+        if self.rd:            
+            self.a = -(1./(self.wv2+self.kd2))[np.newaxis, np.newaxis, :, :]
+        else:
+            self.a = -self.wv2i[np.newaxis, np.newaxis, :, :]
 
     def _initialize_forcing(self):
         pass

--- a/pyqg/bt_model.py
+++ b/pyqg/bt_model.py
@@ -23,7 +23,7 @@ class BTModel(model.Model):
 
     """
 
-    def __init__(self, beta=0.,  rd=0., H=1., U=0., **kwargs):
+    def __init__(self, beta=0.,  rd=None, H=1., U=0., **kwargs):
         """
         Parameters
         ----------


### PR DESCRIPTION
This fixes the inversion matrix `a` for the BT model with free surface.  If a deformation radius is provided, then the inversion matrix `a` is:

` self.a = -1./(self.wv2+self.kd2)`

Otherwise, if  rd is not provided, the model reduces to the 2D vorticity equation, and the `a` is given simply by precomputed inverse wavenumber squared (self.wv2i):

` self.a = -self.wv2i`